### PR TITLE
Fix MKV playback timing

### DIFF
--- a/video_player.h
+++ b/video_player.h
@@ -14,6 +14,7 @@ extern "C"
 #include <libavutil/opt.h>
 #include <libavutil/channel_layout.h>
 #include <libavutil/rational.h>
+#include <libavutil/avutil.h>
 }
 
 #include <vector>
@@ -60,6 +61,8 @@ private:
   double frameRate;
   int64_t currentFrame;
   int64_t totalFrames;
+  double currentPts;
+  double duration;
 
   HWND parentWindow;
   HWND videoWindow;


### PR DESCRIPTION
## Summary
- better guess of video frame rate using `av_guess_frame_rate`
- track timestamps directly from decoded frames
- use actual duration and timestamp values for time display

## Testing
- `cmake ..` *(fails: AVCODEC_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2dfce31c832fbb8a106c33bb5891