### PR TITLE
Improve cut feature and add codec choice

### DIFF
--- a/video_player.h
+++ b/video_player.h
@@ -67,6 +67,7 @@ private:
   int64_t totalFrames;
   double currentPts;
   double duration;
+  std::wstring loadedFilename;
 
   HWND parentWindow;
   HWND videoWindow;
@@ -134,7 +135,7 @@ public:
   float GetAudioTrackVolume(int trackIndex) const;
   void SetAudioTrackVolume(int trackIndex, float volume);
   void SetMasterVolume(float volume);
-  bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime, bool mergeAudio);
+  bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime, bool mergeAudio, bool reencodeToH264, int quality);
 
   // Timer callback
   static void CALLBACK TimerProc(HWND hwnd, UINT msg, UINT_PTR timerId, DWORD time);


### PR DESCRIPTION
## Summary
- fix `CutVideo` stream copy by setting time bases
- store currently loaded filename for reencoding
- allow cutting with fast copy or H.264 reencode
- extend UI with codec radio buttons and quality slider

## Testing
- `cmake ..` *(fails: AVCODEC_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c5690f0832fae71b3de2ebd0be4