### PR TITLE
Fix export success detection

### DIFF
--- a/video_player.h
+++ b/video_player.h
@@ -103,6 +103,9 @@ private:
   int audioChannels;
   AVSampleFormat audioSampleFormat;
 
+  // Currently loaded file path
+  std::wstring loadedFilename;
+
 public:
   VideoPlayer(HWND parent);
   ~VideoPlayer();
@@ -134,7 +137,8 @@ public:
   float GetAudioTrackVolume(int trackIndex) const;
   void SetAudioTrackVolume(int trackIndex, float volume);
   void SetMasterVolume(float volume);
-  bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime, bool mergeAudio);
+  bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime,
+                bool mergeAudio, bool convertH264, int maxBitrate, HWND progressBar);
 
   // Timer callback
   static void CALLBACK TimerProc(HWND hwnd, UINT msg, UINT_PTR timerId, DWORD time);


### PR DESCRIPTION
## Summary
- return failure from `CutVideo` when ffmpeg exits with an error
- use a modifiable command buffer for `CreateProcess`
- reset progress bar before export starts

## Testing
- `cmake -S . -B build` *(fails: AVCODEC_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d67a1119c832f83e856eb64207cd4