### PR TITLE
Fix audio-video sync issue

### DIFF
--- a/video_player.h
+++ b/video_player.h
@@ -1,6 +1,9 @@
 #ifndef VIDEO_PLAYER_H
 #define VIDEO_PLAYER_H
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 
 #include <string>

--- a/video_player.h
+++ b/video_player.h
@@ -27,6 +27,7 @@ extern "C"
 #include <condition_variable>
 #include <deque>
 #include <atomic>
+#include <limits>
 
 // Audio output using Windows Audio Session API (WASAPI)
 #include <mmdeviceapi.h>
@@ -67,6 +68,7 @@ private:
   int64_t totalFrames;
   double currentPts;
   double duration;
+  double startTimeOffset;
 
   HWND parentWindow;
   HWND videoWindow;


### PR DESCRIPTION
## Summary
- sync audio/video by accounting for stream start times
- drop audio frames prior to the earliest video timestamp
- adjust seeking functions for offset

## Testing
- `cmake .` *(fails: AVCODEC_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7e3c3528832f8187842e11e6e3cd