### PR TITLE
Improve timeline seeking and keyboard control

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 - Play, pause, stop controls
 - **Spacebar toggles play/pause** for quick control
 - **Drag and drop** a video onto the window to load it
-- Custom timeline for navigation
-- Click anywhere on the timeline to jump directly to that point
-- Keyboard shortcuts for quick navigation (Left/Right arrows skip 5s, J/L skip 10s, K pauses, ',' and '.' step frames)
+ - Custom timeline bar for navigation with a red time cursor
+ - Click anywhere on the timeline to jump directly to that point
+ - Keyboard shortcuts for quick navigation (Left/Right arrows skip 5s, J/L skip 10s, K pauses, ',' and '.' step frames)
 - Frame-by-frame playback control
 - Hardware-accelerated rendering using Direct2D
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 - **Spacebar toggles play/pause** for quick control
 - **Drag and drop** a video onto the window to load it
 - Seek bar for navigation
+- Click anywhere on the seek bar to jump directly to that point
+- Keyboard shortcuts for quick navigation (Left/Right arrows skip 5s, J/L skip 10s, K pauses, ',' and '.' step frames)
 - Frame-by-frame playback control
 - Hardware-accelerated rendering using Direct2D
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 - **Spacebar toggles play/pause** for quick control
 - **Drag and drop** a video onto the window to load it
  - Custom timeline bar for navigation with a red time cursor
- - Click anywhere on the timeline to jump directly to that point
+ - Click anywhere on the timeline to jump directly to that point or hold and drag to scrub through the video in real time
  - Keyboard shortcuts for quick navigation (Left/Right arrows skip 5s, J/L skip 10s, K pauses, ',' and '.' step frames)
 - Frame-by-frame playback control
 - Hardware-accelerated rendering using Direct2D

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 - **Drag and drop** a video onto the window to load it
 - Seek bar for navigation
 - Click anywhere on the seek bar to jump directly to that point
+- Improved seek bar accuracy when clicking
 - Keyboard shortcuts for quick navigation (Left/Right arrows skip 5s, J/L skip 10s, K pauses, ',' and '.' step frames)
 - Frame-by-frame playback control
 - Hardware-accelerated rendering using Direct2D

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 - Play, pause, stop controls
 - **Spacebar toggles play/pause** for quick control
 - **Drag and drop** a video onto the window to load it
-- Seek bar for navigation
-- Click anywhere on the seek bar to jump directly to that point
-- Improved seek bar accuracy when clicking
+- Custom timeline for navigation
+- Click anywhere on the timeline to jump directly to that point
 - Keyboard shortcuts for quick navigation (Left/Right arrows skip 5s, J/L skip 10s, K pauses, ',' and '.' step frames)
 - Frame-by-frame playback control
 - Hardware-accelerated rendering using Direct2D

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 - **Spacebar toggles play/pause** for quick control
 - **Drag and drop** a video onto the window to load it
  - Custom timeline bar for navigation with a red time cursor
- - Click anywhere on the timeline to jump directly to that point or hold and drag to scrub through the video in real time
+ - Click anywhere on the timeline to jump directly to that point or hold and drag to scrub through the video in real time. Seeking now lands on the exact frame for smoother editing.
  - Keyboard shortcuts for quick navigation (Left/Right arrows skip 5s, J/L skip 10s, K pauses, ',' and '.' step frames)
 - Frame-by-frame playback control
 - Hardware-accelerated rendering using Direct2D

--- a/main.cpp
+++ b/main.cpp
@@ -931,7 +931,9 @@ LRESULT CALLBACK TimelineProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         HDC hdc = BeginPaint(hwnd, &ps);
         RECT rc;
         GetClientRect(hwnd, &rc);
-        FillRect(hdc, &rc, g_hbrBackground);
+        HBRUSH bg = CreateSolidBrush(RGB(70,70,70));
+        FillRect(hdc, &rc, bg);
+        DeleteObject(bg);
         if (g_videoPlayer && g_videoPlayer->IsLoaded())
         {
             double dur = g_videoPlayer->GetDuration();
@@ -974,7 +976,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
     twc.hInstance = hInstance;
     twc.lpszClassName = L"TimelineClass";
     twc.hCursor = LoadCursor(nullptr, IDC_ARROW);
-    twc.hbrBackground = (HBRUSH)GetStockObject(DKGRAY_BRUSH);
+    twc.hbrBackground = nullptr; // custom paint
     RegisterClass(&twc);
 
     HWND hwnd = CreateWindowEx(

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 // main.cpp
 #include <windows.h>
+#include <windowsx.h>
 #include <commdlg.h>  // For file dialog
 #include <commctrl.h> // For common controls
 #include <shellapi.h> // For drag-and-drop

--- a/main.cpp
+++ b/main.cpp
@@ -927,12 +927,13 @@ LRESULT CALLBACK SeekBarProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, 
     case WM_LBUTTONDOWN:
         if (g_videoPlayer && g_videoPlayer->IsLoaded())
         {
-            RECT rc;
-            GetClientRect(hwnd, &rc);
-            int x = GET_X_LPARAM(lParam);
+            RECT channel{};
+            SendMessage(hwnd, TBM_GETCHANNELRECT, 0, (LPARAM)&channel);
+            int x = GET_X_LPARAM(lParam) - channel.left;
             if (x < 0) x = 0;
-            if (x > rc.right) x = rc.right;
-            int pos = (int)((x / (double)rc.right) * SEEK_SLIDER_MAX);
+            int width = channel.right - channel.left;
+            if (x > width) x = width;
+            int pos = (int)((x / (double)width) * SEEK_SLIDER_MAX);
             SendMessage(hwnd, TBM_SETPOS, TRUE, pos);
 
             double duration = g_videoPlayer->GetDuration();
@@ -945,6 +946,7 @@ LRESULT CALLBACK SeekBarProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, 
             if (wasPlaying)
                 g_videoPlayer->Play();
             UpdateControls();
+            return 0;
         }
         break;
     case WM_KEYDOWN:

--- a/main.cpp
+++ b/main.cpp
@@ -947,6 +947,24 @@ LRESULT CALLBACK SeekBarProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, 
             UpdateControls();
         }
         break;
+    case WM_KEYDOWN:
+        // Prevent the trackbar from handling navigation keys when focused
+        switch (wParam)
+        {
+        case VK_LEFT:
+        case VK_RIGHT:
+        case 'J':
+        case 'j':
+        case 'L':
+        case 'l':
+        case 'K':
+        case 'k':
+        case VK_SPACE:
+        case VK_OEM_COMMA:
+        case VK_OEM_PERIOD:
+            return 0;
+        }
+        break;
     }
     return DefSubclassProc(hwnd, msg, wParam, lParam);
 }

--- a/video_player.cpp
+++ b/video_player.cpp
@@ -485,7 +485,7 @@ void VideoPlayer::SeekToTime(double seconds)
 
   currentFrame = (int64_t)(seconds * frameRate);
 
-  int maxFrames = (int)frameRate + 10; // safety cap ~1s
+  int maxFrames = 10; // decode a few frames for accuracy
   DecodeNextFrame();
   while (currentPts < seconds && maxFrames-- > 0)
     DecodeNextFrame();

--- a/video_player.cpp
+++ b/video_player.cpp
@@ -485,10 +485,13 @@ void VideoPlayer::SeekToTime(double seconds)
 
   currentFrame = (int64_t)(seconds * frameRate);
 
-  int maxFrames = 10; // decode a few frames for accuracy
+  int maxFrames = frameRate > 0 ? (int)(frameRate * 3) : 90; // decode up to ~3s
   DecodeNextFrame();
   while (currentPts < seconds && maxFrames-- > 0)
-    DecodeNextFrame();
+  {
+    if (!DecodeNextFrame())
+      break;
+  }
 }
 
 double VideoPlayer::GetDuration() const

--- a/video_player.cpp
+++ b/video_player.cpp
@@ -455,35 +455,24 @@ void VideoPlayer::UpdateDisplay()
 
 void VideoPlayer::SeekToFrame(int64_t frameNumber)
 {
-  if (!isLoaded || frameNumber < 0 || frameNumber >= totalFrames)
+  if (!isLoaded)
     return;
-  AVStream *vs = formatContext->streams[videoStreamIndex];
-  AVRational fps = av_d2q(frameRate, 100000);
-  int64_t ts = av_rescale_q(frameNumber, av_inv_q(fps), vs->time_base);
-  ts += (int64_t)(startTimeOffset / av_q2d(vs->time_base));
-  av_seek_frame(formatContext, videoStreamIndex, ts, AVSEEK_FLAG_BACKWARD);
-  avcodec_flush_buffers(codecContext);
-  for (auto &track : audioTracks)
-  {
-    if (track->codecContext)
-      avcodec_flush_buffers(track->codecContext);
-  }
-  {
-    std::lock_guard<std::mutex> lock(audioMutex);
-    for (auto& tr : audioTracks)
-      tr->buffer.clear();
-  }
-  currentFrame = frameNumber;
-  currentPts = frameNumber / frameRate;
-  DecodeNextFrame();
+  if (frameNumber < 0)
+    frameNumber = 0;
+  if (totalFrames > 0 && frameNumber >= totalFrames)
+    frameNumber = totalFrames - 1;
+  double targetTime = frameNumber / frameRate;
+  SeekToTime(targetTime);
 }
 
 void VideoPlayer::SeekToTime(double seconds)
 {
   if (!isLoaded)
     return;
+
   AVStream *vs = formatContext->streams[videoStreamIndex];
   int64_t ts = (int64_t)((seconds + startTimeOffset) / av_q2d(vs->time_base));
+
   av_seek_frame(formatContext, videoStreamIndex, ts, AVSEEK_FLAG_BACKWARD);
   avcodec_flush_buffers(codecContext);
   for (auto &track : audioTracks)
@@ -496,9 +485,15 @@ void VideoPlayer::SeekToTime(double seconds)
     for (auto& tr : audioTracks)
       tr->buffer.clear();
   }
-  currentFrame = (int64_t)(seconds * frameRate);
-  currentPts = seconds;
-  DecodeNextFrame();
+
+  // Decode frames until we reach the requested time
+  while (DecodeNextFrame())
+  {
+    if (currentPts + (1.0 / std::max(1.0, frameRate)) / 2.0 >= seconds)
+      break;
+  }
+  // Adjust frame index approximation
+  currentFrame = static_cast<int64_t>(currentPts * frameRate);
 }
 
 double VideoPlayer::GetDuration() const


### PR DESCRIPTION
## Summary
- subclass seek slider so clicking seeks precisely
- add keyboard shortcuts for navigating playback

## Testing
- `cmake -S . -B build` *(fails: AVCODEC_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d894a1754832fb060076e5f5e8f79