### PR TITLE
Fix mapping of audio streams for ffmpeg cut

### DIFF
--- a/video_player.h
+++ b/video_player.h
@@ -40,6 +40,7 @@ extern "C"
 // Audio track structure
 struct AudioTrack {
     int streamIndex;
+    int audioIndex; // index among audio streams for ffmpeg mapping
     AVCodecContext *codecContext;
     SwrContext *swrContext;
     AVFrame *frame;
@@ -48,7 +49,7 @@ struct AudioTrack {
     std::string name;
     std::deque<int16_t> buffer;
     
-    AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
+    AudioTrack() : streamIndex(-1), audioIndex(-1), codecContext(nullptr), swrContext(nullptr),
                    frame(nullptr), isMuted(false), volume(1.0f) {}
 };
 


### PR DESCRIPTION
## Summary
- include audio stream index for ffmpeg mapping
- avoid mapping subtitle streams when cutting video

## Testing
- `g++ -std=c++17 -c video_player.cpp` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc345d94c832fb82ab75d1834f5d5