### PR TITLE
Improve static build performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.10)
 project(VideoEditor CXX)
 
+# Option to link FFmpeg statically
+option(USE_STATIC_FFMPEG "Link FFmpeg statically" OFF)
+
+if(MSVC AND USE_STATIC_FFMPEG)
+    # Link the MSVC runtime statically when building a portable executable
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    # Enable link-time optimization to reduce overhead in the static build
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -74,8 +84,8 @@ target_link_libraries(VideoEditor PRIVATE
     ${SWRESAMPLE_LIBRARY}
 )
 
-# Copy FFmpeg DLLs to output directory after build
-if(WIN32)
+# Copy FFmpeg DLLs when linking dynamically
+if(WIN32 AND NOT USE_STATIC_FFMPEG)
     add_custom_command(TARGET VideoEditor POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avcodec-62.dll" "$<TARGET_FILE_DIR:VideoEditor>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avformat-62.dll" "$<TARGET_FILE_DIR:VideoEditor>"

--- a/README.md
+++ b/README.md
@@ -66,10 +66,45 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 - FFmpeg development libraries
 
 ### Build Steps
-1. Extract FFmpeg to `C:/Program Files/ffmpeg` (or update CMakeLists.txt path)
-2. Create build directory: `mkdir build && cd build`
-3. Generate project: `cmake ..`
-4. Build: `cmake --build . --config Release`
+The project can be built against the regular FFmpeg DLLs or the static
+libraries provided by `vcpkg`. Building with the static libraries produces a
+single `VideoEditor.exe` that does not need FFmpeg DLLs at runtime.
+
+1. **Using the prebuilt shared FFmpeg binaries** (default)
+   1. Extract FFmpeg to `C:/Program Files/ffmpeg` (or set `FFMPEG_ROOT` when
+      configuring CMake).
+   2. Create a build directory: `mkdir build && cd build`
+   3. Generate the project: `cmake ..`
+   4. Build: `cmake --build . --config Release`
+
+2. **Building a portable executable with static FFmpeg**
+   1. Install FFmpeg via vcpkg using the static triplet:
+      ```
+      vcpkg install ffmpeg:x64-windows-static
+      ```
+   2. Configure CMake pointing `FFMPEG_ROOT` to the vcpkg installation and
+      enabling static linking:
+   ```
+   cmake -S . -B build -DFFMPEG_ROOT="C:/tools/vcpkg/installed/x64-windows-static" -DUSE_STATIC_FFMPEG=ON
+   ```
+   3. Build the release configuration:
+      ```
+   cmake --build build --config Release
+   ```
+   The resulting `VideoEditor.exe` no longer requires FFmpeg DLLs.
+
+   Link-time optimization is automatically enabled when `USE_STATIC_FFMPEG` is
+   used to keep performance similar to the dynamic build.
+
+Alternatively you can use the provided `run.ps1` script:
+
+```powershell
+./run.ps1 -Static
+```
+
+When `-Static` is used the script looks for FFmpeg in
+`C:\tools\vcpkg\installed\x64-windows-static` unless another path is passed
+via `-FFmpegPath`.
 
 ### FFmpeg Libraries Required
 - avcodec (video/audio decoding)


### PR DESCRIPTION
## Summary
- enable link-time optimization when building with USE_STATIC_FFMPEG
- document that LTO is enabled for static builds to match performance

## Testing
- `cmake -S . -B build` *(fails: AVCODEC_LIBRARY NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_685ebc34d7cc832f9acdd4f321698238