### PR TITLE
Improve seeking performance

### DIFF
--- a/video_player.h
+++ b/video_player.h
@@ -47,6 +47,7 @@ struct AudioTrack {
     float volume;
     std::string name;
     std::deque<int16_t> buffer;
+    std::vector<int16_t> resampleBuffer;
     
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
                    frame(nullptr), isMuted(false), volume(1.0f) {}


### PR DESCRIPTION
## Summary
- add reusable audio resample buffer for each audio track
- switch video scaling to `SWS_FAST_BILINEAR` for quicker frame conversion

## Testing
- `cmake ..` *(fails: FFmpeg libs not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec6d2f4c0832f9a0d2b24085a2c21