### PR TITLE
Fix static FFmpeg link errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,18 @@ if(FFMPEG_INCLUDE_DIR)
 endif()
 
 # Link libraries
+set(FFMPEG_EXTRA_LIBS "")
+if(USE_STATIC_FFMPEG)
+    # When linking the static variant from vcpkg, FFmpeg depends on several
+    # additional libraries (zlib, libxml2, libmp3lame, etc.).  Rather than
+    # hardcoding each one, gather all libraries in the FFmpeg lib folder and
+    # link them as well.  This prevents unresolved symbols when optional
+    # features are enabled.
+    file(GLOB _all_ffmpeg_libs "${FFMPEG_ROOT}/lib/*.lib")
+    list(FILTER _all_ffmpeg_libs EXCLUDE REGEX "avcodec|avformat|avutil|swscale|swresample")
+    set(FFMPEG_EXTRA_LIBS ${_all_ffmpeg_libs})
+endif()
+
 target_link_libraries(VideoEditor PRIVATE
     user32
     gdi32
@@ -89,6 +101,7 @@ target_link_libraries(VideoEditor PRIVATE
     ${AVUTIL_LIBRARY}
     ${SWSCALE_LIBRARY}
     ${SWRESAMPLE_LIBRARY}
+    ${FFMPEG_EXTRA_LIBS}
 )
 
 # Copy FFmpeg DLLs when linking dynamically

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ single `VideoEditor.exe` that does not need FFmpeg DLLs at runtime.
    4. Build: `cmake --build . --config Release`
 
 2. **Building a portable executable with static FFmpeg**
-   1. Install FFmpeg via vcpkg using the static triplet:
+   1. Install FFmpeg via vcpkg using the static triplet.  You may enable
+      additional codec features if desired:
       ```
-      vcpkg install ffmpeg:x64-windows-static
+      vcpkg install ffmpeg[dav1d,avcodec,avformat,avfilter,swscale,swresample,freetype,fribidi,fontconfig,mp3lame,opus,vpx,webp,openjpeg,zlib,xml2]:x64-windows-static
       ```
    2. Configure CMake pointing `FFMPEG_ROOT` to the vcpkg installation and
       enabling static linking:


### PR DESCRIPTION
## Summary
- gather all FFmpeg libs when linking statically
- document installing FFmpeg with extra codec features

## Testing
- `cmake -S . -B build_test -DFFMPEG_ROOT="/tmp"` *(fails: AVCODEC_LIBRARY NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_685f261f72cc832fb510832c92ec7d65