### PR TITLE
Fix static build runtime config for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
+
+# Ensure newer policy for MSVC runtime selection when available
+if(POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW)
+endif()
 project(VideoEditor CXX)
 
 # Option to link FFmpeg statically

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A Windows-based video player application built with C++ and FFmpeg that supports
 
 ### Prerequisites
 - Visual Studio 2019 or later
-- CMake 3.10 or later
+ - CMake 3.10 or later (3.15+ recommended for static linking)
 - FFmpeg development libraries
 
 ### Build Steps


### PR DESCRIPTION
## Summary
- ensure CMP0091 is enabled so CMAKE_MSVC_RUNTIME_LIBRARY takes effect
- clarify CMake version recommendation in README

## Testing
- `cmake -S . -B build` *(fails: FFmpeg libs not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f34228324832f8b0f9a7025d7a539