### PR TITLE
Fix audio synchronization

### DIFF
--- a/video_player.cpp
+++ b/video_player.cpp
@@ -143,7 +143,6 @@ bool VideoPlayer::LoadVideo(const std::wstring &filename)
 
   isLoaded = true;
   currentFrame = 0;
-  AVStream *vs = formatContext->streams[videoStreamIndex];
   AVRational guessed = av_guess_frame_rate(formatContext, vs, nullptr);
   frameRate = guessed.num && guessed.den ? av_q2d(guessed) : 0.0;
   if (frameRate <= 0.0)

--- a/video_player.cpp
+++ b/video_player.cpp
@@ -694,13 +694,14 @@ bool VideoPlayer::InitializeAudio()
   audioFormat->nAvgBytesPerSec = audioFormat->nSamplesPerSec * audioFormat->nBlockAlign;
   audioFormat->cbSize = 0;
 
-  hr = audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 10000000, 0, audioFormat, nullptr);
+  // Use a smaller buffer to minimize latency (200 ms)
+  hr = audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 2000000, 0, audioFormat, nullptr);
   if (FAILED(hr))
   {
     // Try with device format if our format fails
     CoTaskMemFree(audioFormat);
     audioFormat = deviceFormat;
-    hr = audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 10000000, 0, audioFormat, nullptr);
+    hr = audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 2000000, 0, audioFormat, nullptr);
     if (FAILED(hr))
       return false;
   }

--- a/video_player.h
+++ b/video_player.h
@@ -48,9 +48,10 @@ struct AudioTrack {
     std::string name;
     std::deque<int16_t> buffer;
     std::vector<int16_t> resampleBuffer;
-    
+    double nextPts;
+
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
-                   frame(nullptr), isMuted(false), volume(1.0f) {}
+                   frame(nullptr), isMuted(false), volume(1.0f), nextPts(0.0) {}
 };
 
 class VideoPlayer

--- a/video_player.h
+++ b/video_player.h
@@ -50,10 +50,11 @@ struct AudioTrack {
     std::vector<int16_t> resampleBuffer;
     double nextPts;
     double startOffset;
+    bool   startOffsetSet;
 
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
                    frame(nullptr), isMuted(false), volume(1.0f), nextPts(0.0),
-                   startOffset(0.0) {}
+                   startOffset(0.0), startOffsetSet(false) {}
 };
 
 class VideoPlayer

--- a/video_player.h
+++ b/video_player.h
@@ -49,9 +49,11 @@ struct AudioTrack {
     std::deque<int16_t> buffer;
     std::vector<int16_t> resampleBuffer;
     double nextPts;
+    double startOffset;
 
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
-                   frame(nullptr), isMuted(false), volume(1.0f), nextPts(0.0) {}
+                   frame(nullptr), isMuted(false), volume(1.0f), nextPts(0.0),
+                   startOffset(0.0) {}
 };
 
 class VideoPlayer


### PR DESCRIPTION
## Summary
- avoid large audio gaps by tracking audio timestamps
- clear audio timing state when stopping or seeking

## Testing
- `cmake -S . -B build` *(fails: libraries not found)*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_686c5b9541a8832fa150bc21a6cc1eac