### PR TITLE
Fix AV1 playback crash on window resize

### DIFF
--- a/video_player.h
+++ b/video_player.h
@@ -159,7 +159,7 @@ public:
 private:
   bool InitializeDecoder();
   void CleanupDecoder();
-  bool DecodeNextFrame();
+  bool DecodeNextFrame(bool updateDisplay = true);
   void UpdateDisplay();
   void CreateVideoWindow();
   


### PR DESCRIPTION
## Summary
- update VideoPlayer to render frames on UI thread only
- guard UpdateDisplay with mutex and invalidate the window from the decode thread
- adjust calls to DecodeNextFrame with a new parameter

## Testing
- `cmake ..` *(fails: AVFORMAT_LIBRARY NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686d41f9efe4832f98931abe63b86236