### PR TITLE
Cancel export on progress window close

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -302,8 +302,29 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         CloseProgressWindow();
         EnableWindow(hwnd, TRUE);
         bool success = wParam != 0;
-        MessageBoxW(hwnd, success ? L"Video successfully cut and saved." : L"Failed to cut the video.",
-                    success ? L"Success" : L"Error", MB_OK | (success ? MB_ICONINFORMATION : MB_ICONERROR));
+        const wchar_t* msg;
+        const wchar_t* title;
+        UINT flags;
+        if (success)
+        {
+            msg = L"Video successfully cut and saved.";
+            title = L"Success";
+            flags = MB_OK | MB_ICONINFORMATION;
+        }
+        else if (g_cancelExport)
+        {
+            msg = L"Export canceled.";
+            title = L"Canceled";
+            flags = MB_OK | MB_ICONINFORMATION;
+        }
+        else
+        {
+            msg = L"Failed to cut the video.";
+            title = L"Error";
+            flags = MB_OK | MB_ICONERROR;
+        }
+        MessageBoxW(hwnd, msg, title, flags);
+        g_cancelExport = false;
         UpdateControls();
     }
     break;

--- a/video_player.h
+++ b/video_player.h
@@ -151,7 +151,7 @@ public:
   void SetMasterVolume(float volume);
   bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime,
                 bool mergeAudio, bool convertH264, bool useNvenc,
-                int maxBitrate, HWND progressBar);
+                int maxBitrate, HWND progressBar, std::atomic<bool>* cancelFlag);
 
   // Timer callback
   static void CALLBACK TimerProc(HWND hwnd, UINT msg, UINT_PTR timerId, DWORD time);


### PR DESCRIPTION
## Summary
- add `g_cancelExport` flag and progress window procedure
- register `ProgressClass` window and set cancellation flag when closing
- update `CutVideo` to support external cancellation and guard progress bar updates

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_686d5794d86c832f89800ed15f9f452e