### PR TITLE
Add persistent options dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ find_library(SWRESAMPLE_LIBRARY
 )
 
 # Create the executable
-add_executable(VideoEditor WIN32 main.cpp video_player.cpp video_player.h)
+add_executable(VideoEditor WIN32 main.cpp video_player.cpp options_window.cpp video_player.h)
 
 # Include FFmpeg headers
 if(FFMPEG_INCLUDE_DIR)

--- a/options_window.cpp
+++ b/options_window.cpp
@@ -1,0 +1,121 @@
+#include "options_window.h"
+
+// Forward declaration from main.cpp for styling
+void ApplyDarkTheme(HWND hwnd);
+
+static HWND g_hOptionsWnd = nullptr;
+
+// Global option variables
+bool g_useNvenc = false;
+bool g_logToFile = true;
+
+// Load settings from Windows registry
+void LoadSettings()
+{
+    HKEY hKey;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\VideoEditor", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
+        DWORD val; DWORD size = sizeof(val);
+        if (RegQueryValueExW(hKey, L"UseNvenc", nullptr, nullptr, (LPBYTE)&val, &size) == ERROR_SUCCESS)
+            g_useNvenc = (val != 0);
+        size = sizeof(val);
+        if (RegQueryValueExW(hKey, L"EnableLogFile", nullptr, nullptr, (LPBYTE)&val, &size) == ERROR_SUCCESS)
+            g_logToFile = (val != 0);
+        RegCloseKey(hKey);
+    }
+}
+
+// Save settings to Windows registry
+void SaveSettings()
+{
+    HKEY hKey;
+    if (RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\VideoEditor", 0, nullptr, 0, KEY_WRITE, nullptr, &hKey, nullptr) == ERROR_SUCCESS) {
+        DWORD val = g_useNvenc ? 1 : 0;
+        RegSetValueExW(hKey, L"UseNvenc", 0, REG_DWORD, (const BYTE*)&val, sizeof(val));
+        val = g_logToFile ? 1 : 0;
+        RegSetValueExW(hKey, L"EnableLogFile", 0, REG_DWORD, (const BYTE*)&val, sizeof(val));
+        RegCloseKey(hKey);
+    }
+}
+
+void ShowOptionsWindow(HWND parent)
+{
+    if (g_hOptionsWnd) {
+        SetForegroundWindow(g_hOptionsWnd);
+        return;
+    }
+
+    g_hOptionsWnd = CreateWindowEx(0, L"OptionsClass", L"Options",
+                                   WS_CAPTION | WS_POPUPWINDOW | WS_VISIBLE,
+                                   CW_USEDEFAULT, CW_USEDEFAULT, 220, 180,
+                                   parent, nullptr,
+                                   (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(g_hOptionsWnd);
+
+    CreateWindow(L"STATIC", L"Encode H264:", WS_CHILD | WS_VISIBLE,
+                 10, 10, 120, 20, g_hOptionsWnd, nullptr,
+                 (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
+    HWND hLib = CreateWindow(L"BUTTON", L"libx264",
+                             WS_CHILD | WS_VISIBLE | BS_AUTORADIOBUTTON,
+                             10, 40, 100, 20, g_hOptionsWnd,
+                             (HMENU)ID_RADIO_ENCODER_LIBX264,
+                             (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
+    HWND hNv = CreateWindow(L"BUTTON", L"NVENC h264",
+                            WS_CHILD | WS_VISIBLE | BS_AUTORADIOBUTTON,
+                            10, 65, 120, 20, g_hOptionsWnd,
+                            (HMENU)ID_RADIO_ENCODER_NVENC,
+                            (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
+    HWND hLog = CreateWindow(L"BUTTON", L"Enable log file",
+                             WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX,
+                             10, 90, 150, 20, g_hOptionsWnd,
+                             (HMENU)ID_CHECKBOX_ENABLE_LOG,
+                             (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(hLib);
+    ApplyDarkTheme(hNv);
+    ApplyDarkTheme(hLog);
+    HWND hOk = CreateWindow(L"BUTTON", L"OK",
+                            WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
+                            30, 120, 70, 25, g_hOptionsWnd,
+                            (HMENU)IDOK,
+                            (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
+    HWND hCancel = CreateWindow(L"BUTTON", L"Cancel",
+                                WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+                                110, 120, 70, 25, g_hOptionsWnd,
+                                (HMENU)IDCANCEL,
+                                (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(hOk);
+    ApplyDarkTheme(hCancel);
+
+    SendMessage(hLib, BM_SETCHECK, g_useNvenc ? BST_UNCHECKED : BST_CHECKED, 0);
+    SendMessage(hNv, BM_SETCHECK, g_useNvenc ? BST_CHECKED : BST_UNCHECKED, 0);
+    SendMessage(hLog, BM_SETCHECK, g_logToFile ? BST_CHECKED : BST_UNCHECKED, 0);
+}
+
+LRESULT CALLBACK OptionsProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg) {
+    case WM_COMMAND:
+        if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL) {
+            HWND hNv = GetDlgItem(hwnd, ID_RADIO_ENCODER_NVENC);
+            HWND hLog = GetDlgItem(hwnd, ID_CHECKBOX_ENABLE_LOG);
+            g_useNvenc = SendMessage(hNv, BM_GETCHECK, 0, 0) == BST_CHECKED;
+            g_logToFile = SendMessage(hLog, BM_GETCHECK, 0, 0) == BST_CHECKED;
+            SaveSettings();
+            DestroyWindow(hwnd);
+        }
+        break;
+    case WM_CLOSE:
+        {
+            HWND hNv = GetDlgItem(hwnd, ID_RADIO_ENCODER_NVENC);
+            HWND hLog = GetDlgItem(hwnd, ID_CHECKBOX_ENABLE_LOG);
+            g_useNvenc = SendMessage(hNv, BM_GETCHECK, 0, 0) == BST_CHECKED;
+            g_logToFile = SendMessage(hLog, BM_GETCHECK, 0, 0) == BST_CHECKED;
+            SaveSettings();
+            DestroyWindow(hwnd);
+        }
+        break;
+    case WM_DESTROY:
+        g_hOptionsWnd = nullptr;
+        break;
+    }
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}

--- a/options_window.h
+++ b/options_window.h
@@ -1,0 +1,19 @@
+#ifndef OPTIONS_WINDOW_H
+#define OPTIONS_WINDOW_H
+
+#include <windows.h>
+
+// Option identifiers used in the options window
+#define ID_RADIO_ENCODER_LIBX264 1021
+#define ID_RADIO_ENCODER_NVENC  1022
+#define ID_CHECKBOX_ENABLE_LOG  1023
+
+extern bool g_useNvenc;
+extern bool g_logToFile;
+
+void ShowOptionsWindow(HWND parent);
+LRESULT CALLBACK OptionsProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+void LoadSettings();
+void SaveSettings();
+
+#endif // OPTIONS_WINDOW_H

--- a/video_player.cpp
+++ b/video_player.cpp
@@ -1,5 +1,6 @@
 // video_player.cpp
 #include "video_player.h"
+#include "options_window.h"
 #include <iostream>
 #include <sstream>
 #include <cstdlib>
@@ -15,13 +16,16 @@
 #include <chrono>
 
 // Simple debug logging helper that also writes to a file and can show popups
+
 static std::ofstream g_debugFile;
 static void DebugLog(const std::string& msg, bool popup = false)
 {
-    if (!g_debugFile.is_open())
-        g_debugFile.open("debug.log", std::ios::app);
-    if (g_debugFile.is_open())
-        g_debugFile << msg << std::endl;
+    if (g_logToFile) {
+        if (!g_debugFile.is_open())
+            g_debugFile.open("debug.log", std::ios::app);
+        if (g_debugFile.is_open())
+            g_debugFile << msg << std::endl;
+    }
 
     OutputDebugStringA((msg + "\n").c_str());
     if (popup)


### PR DESCRIPTION
## Summary
- refactor the encoder options window into new `options_window` files
- allow toggling debug log generation
- persist NVENC and log settings to the Windows registry
- use the saved options on startup
- compile the new files via CMake

## Testing
- `cmake -S . -B build` *(fails: AVCODEC_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5bfb8170832faa1b8aa78a655268