### PR TITLE
Refactor progress window into separate module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(VideoEditor WIN32
     src/main.cpp
     src/video_player.cpp
     src/options_window.cpp
+    src/progress_window.cpp
 )
 
 # Headers live in src/

--- a/src/progress_window.cpp
+++ b/src/progress_window.cpp
@@ -1,0 +1,63 @@
+#include "progress_window.h"
+#include <commctrl.h>
+#include <uxtheme.h>
+#pragma comment(lib, "comctl32.lib")
+
+HWND g_hProgressWnd = nullptr;
+HWND g_hProgressBar = nullptr;
+std::atomic<bool> g_cancelExport{false};
+
+// Forward declaration from main.cpp for styling
+void ApplyDarkTheme(HWND hwnd);
+
+void ShowProgressWindow(HWND parent)
+{
+    INITCOMMONCONTROLSEX ic = {sizeof(ic), ICC_PROGRESS_CLASS};
+    InitCommonControlsEx(&ic);
+    g_cancelExport = false;
+    g_hProgressWnd = CreateWindowEx(WS_EX_TOPMOST, L"ProgressClass", L"Exporting", WS_CAPTION | WS_POPUPWINDOW,
+                                   CW_USEDEFAULT, CW_USEDEFAULT, 300, 100,
+                                   parent, nullptr, (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(g_hProgressWnd);
+    g_hProgressBar = CreateWindowEx(0, PROGRESS_CLASS, nullptr,
+                                   WS_CHILD | WS_VISIBLE, 20, 30, 260, 20,
+                                   g_hProgressWnd, nullptr, (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
+    SendMessage(g_hProgressBar, PBM_SETRANGE, 0, MAKELPARAM(0, 100));
+    ShowWindow(g_hProgressWnd, SW_SHOW);
+    UpdateWindow(g_hProgressWnd);
+}
+
+void UpdateProgress(int percent)
+{
+    if (g_hProgressBar)
+        SendMessage(g_hProgressBar, PBM_SETPOS, percent, 0);
+}
+
+void CloseProgressWindow()
+{
+    if (g_hProgressWnd)
+    {
+        DestroyWindow(g_hProgressWnd);
+        g_hProgressWnd = nullptr;
+        g_hProgressBar = nullptr;
+    }
+}
+
+LRESULT CALLBACK ProgressProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_CLOSE:
+        g_cancelExport = true;
+        DestroyWindow(hwnd);
+        return 0;
+    case WM_DESTROY:
+        if (hwnd == g_hProgressWnd)
+        {
+            g_hProgressWnd = nullptr;
+            g_hProgressBar = nullptr;
+        }
+        break;
+    }
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}

--- a/src/progress_window.h
+++ b/src/progress_window.h
@@ -1,0 +1,16 @@
+#ifndef PROGRESS_WINDOW_H
+#define PROGRESS_WINDOW_H
+
+#include <windows.h>
+#include <atomic>
+
+extern HWND g_hProgressWnd;
+extern HWND g_hProgressBar;
+extern std::atomic<bool> g_cancelExport;
+
+void ShowProgressWindow(HWND parent);
+void UpdateProgress(int percent);
+void CloseProgressWindow();
+LRESULT CALLBACK ProgressProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+#endif // PROGRESS_WINDOW_H


### PR DESCRIPTION
## Summary
- split progress window implementation from `main.cpp`
- add new `progress_window.h/cpp`
- adjust CMakeLists to compile the new file

## Testing
- `cmake -S . -B build` *(fails: AVCODEC_LIBRARY NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686d616d597c832f8d17d017f1c913a1