### PR TITLE
Add export button when no cut points

### DIFF
--- a/src/editing.h
+++ b/src/editing.h
@@ -5,3 +5,6 @@
 void OnSetStartClicked(HWND hwnd);
 void OnSetEndClicked(HWND hwnd);
 void OnCutClicked(HWND hwnd);
+void OnExportClicked(HWND hwnd);
+
+extern bool g_lastOperationWasExport;

--- a/src/ui_controls.cpp
+++ b/src/ui_controls.cpp
@@ -232,7 +232,7 @@ void CreateControls(HWND hwnd)
     ApplyDarkTheme(g_hLabelCutInfo);
 
     g_hButtonCut = CreateWindow(
-        L"BUTTON", L"Cut & Save",
+        L"BUTTON", L"Export Video",
         WS_VISIBLE | WS_CHILD | BS_PUSHBUTTON,
         340, 450, 200, 30, // Placeholder
         hwnd, (HMENU)ID_BUTTON_CUT,

--- a/src/ui_updates.cpp
+++ b/src/ui_updates.cpp
@@ -36,7 +36,18 @@ void UpdateControls()
     EnableWindow(g_hButtonSetEnd, isLoaded);
     EnableWindow(g_hEditStartTime, isLoaded);
     EnableWindow(g_hEditEndTime, isLoaded);
-    EnableWindow(g_hButtonCut, isLoaded && g_cutStartTime >= 0 && g_cutEndTime > g_cutStartTime);
+    bool hasStart = g_cutStartTime >= 0;
+    bool hasEnd = g_cutEndTime >= 0;
+    if (!hasStart && !hasEnd)
+    {
+        SetWindowTextW(g_hButtonCut, L"Export Video");
+        EnableWindow(g_hButtonCut, isLoaded);
+    }
+    else
+    {
+        SetWindowTextW(g_hButtonCut, L"Cut Video");
+        EnableWindow(g_hButtonCut, isLoaded && hasStart && hasEnd && g_cutEndTime > g_cutStartTime);
+    }
 
    bool canMerge = g_videoPlayer && g_videoPlayer->GetAudioTrackCount() > 1;
    EnableWindow(g_hCheckboxMergeAudio, isLoaded && canMerge);


### PR DESCRIPTION
## Summary
- allow clearing start and end cut times by emptying the edit fields
- convert cut button to an export button when no cut points are set
- implement `OnExportClicked` and track operation type for success messages
- update button behavior and labels according to cut point status

## Testing
- `cmake -S . -B build` *(fails: FFmpeg libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da12240c4832fa81eba21c00afd18