### PR TITLE
Improve AV sync with audio clock

### DIFF
--- a/src/video_player.h
+++ b/src/video_player.h
@@ -111,6 +111,8 @@ public:
     WAVEFORMATEX *audioFormat;
     UINT32 bufferFrameCount;
     bool audioInitialized;
+    IAudioClock* audioClock;
+    HANDLE audioEvent;
     
     // Audio threading
     std::thread audioThread;


### PR DESCRIPTION
## Summary
- use WASAPI event callback and IAudioClock
- drive video timing from audio clock
- wait on WASAPI event instead of busy waiting
- add clock and event handles to `VideoPlayer`

## Testing
- `cmake -S . -B build` *(fails: AVCODEC_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db5425f3c832f8b2d040896b61369