### PR TITLE
Fix H264 bitrate handling

### DIFF
--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -157,20 +157,6 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                 vEncCtx->rc_max_rate    = br;
                 vEncCtx->rc_min_rate    = br;
                 vEncCtx->rc_buffer_size = br * 2;
-                if (vEncCtx->priv_data) {
-                    av_opt_set_int(vEncCtx->priv_data, "bitrate", br, 0);
-                    av_opt_set_int(vEncCtx->priv_data, "b", br, 0);
-                    av_opt_set_int(vEncCtx->priv_data, "maxrate", br, 0);
-                    av_opt_set_int(vEncCtx->priv_data, "minrate", br, 0);
-                    av_opt_set_int(vEncCtx->priv_data, "bufsize", br * 2, 0);
-                    av_opt_set       (vEncCtx->priv_data, "nal-hrd", "cbr", 0);
-                    if (useNvenc) {
-                        av_opt_set(vEncCtx->priv_data, "rc", "cbr", 0);
-                        av_opt_set(vEncCtx->priv_data, "cbr", "1", 0);
-                        av_opt_set(vEncCtx->priv_data, "cbr_padding", "1", 0);
-                        av_opt_set(vEncCtx->priv_data, "strict_gop", "1", 0);
-                    }
-                }
             }
             if (outputCtx->oformat->flags & AVFMT_GLOBALHEADER)
                 vEncCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
@@ -191,6 +177,8 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                     av_dict_set(&encOpts, "cbr", "1", 0);
                     av_dict_set(&encOpts, "cbr_padding", "1", 0);
                     av_dict_set(&encOpts, "strict_gop", "1", 0);
+                    av_dict_set(&encOpts, "profile", "high", 0);
+                    av_dict_set(&encOpts, "rc-lookahead", "0", 0);
                 }
             }
             if (avcodec_open2(vEncCtx, vEnc, &encOpts) < 0) {

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -153,19 +153,34 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
             vEncCtx->gop_size = 12;
             if (maxBitrate > 0) {
                 int br = maxBitrate * 1000;
-                vEncCtx->bit_rate      = br;
-                vEncCtx->rc_max_rate   = br;
-                vEncCtx->rc_min_rate   = br;
-                vEncCtx->rc_buffer_size= br;
+                vEncCtx->bit_rate       = br;
+                vEncCtx->rc_max_rate    = br;
+                vEncCtx->rc_min_rate    = br;
+                vEncCtx->rc_buffer_size = br * 2;
                 if (vEncCtx->priv_data) {
                     av_opt_set_int(vEncCtx->priv_data, "bitrate", br, 0);
                     av_opt_set_int(vEncCtx->priv_data, "b", br, 0);
+                    av_opt_set_int(vEncCtx->priv_data, "maxrate", br, 0);
+                    av_opt_set_int(vEncCtx->priv_data, "minrate", br, 0);
+                    av_opt_set_int(vEncCtx->priv_data, "bufsize", br * 2, 0);
+                    av_opt_set       (vEncCtx->priv_data, "nal-hrd", "cbr", 0);
                 }
             }
             if (outputCtx->oformat->flags & AVFMT_GLOBALHEADER)
                 vEncCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
             AVDictionary* encOpts = nullptr;
             av_dict_set(&encOpts, "preset", "fast", 0);
+            if (maxBitrate > 0) {
+                char brStr[32];
+                snprintf(brStr, sizeof(brStr), "%dk", maxBitrate);
+                av_dict_set(&encOpts, "b", brStr, 0);
+                av_dict_set(&encOpts, "minrate", brStr, 0);
+                av_dict_set(&encOpts, "maxrate", brStr, 0);
+                char bufStr[32];
+                snprintf(bufStr, sizeof(bufStr), "%dk", maxBitrate * 2);
+                av_dict_set(&encOpts, "bufsize", bufStr, 0);
+                av_dict_set(&encOpts, "nal-hrd", "cbr", 0);
+            }
             if (avcodec_open2(vEncCtx, vEnc, &encOpts) < 0) {
                 DebugLog("Failed to open H.264 encoder", true);
                 avcodec_free_context(&vEncCtx);

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -164,8 +164,12 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                     av_opt_set_int(vEncCtx->priv_data, "minrate", br, 0);
                     av_opt_set_int(vEncCtx->priv_data, "bufsize", br * 2, 0);
                     av_opt_set       (vEncCtx->priv_data, "nal-hrd", "cbr", 0);
-                    if (useNvenc)
+                    if (useNvenc) {
                         av_opt_set(vEncCtx->priv_data, "rc", "cbr", 0);
+                        av_opt_set(vEncCtx->priv_data, "cbr", "1", 0);
+                        av_opt_set(vEncCtx->priv_data, "cbr_padding", "1", 0);
+                        av_opt_set(vEncCtx->priv_data, "strict_gop", "1", 0);
+                    }
                 }
             }
             if (outputCtx->oformat->flags & AVFMT_GLOBALHEADER)
@@ -182,8 +186,12 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                 snprintf(bufStr, sizeof(bufStr), "%dk", maxBitrate * 2);
                 av_dict_set(&encOpts, "bufsize", bufStr, 0);
                 av_dict_set(&encOpts, "nal-hrd", "cbr", 0);
-                if (useNvenc)
+                if (useNvenc) {
                     av_dict_set(&encOpts, "rc", "cbr", 0);
+                    av_dict_set(&encOpts, "cbr", "1", 0);
+                    av_dict_set(&encOpts, "cbr_padding", "1", 0);
+                    av_dict_set(&encOpts, "strict_gop", "1", 0);
+                }
             }
             if (avcodec_open2(vEncCtx, vEnc, &encOpts) < 0) {
                 DebugLog("Failed to open H.264 encoder", true);

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -164,6 +164,8 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                     av_opt_set_int(vEncCtx->priv_data, "minrate", br, 0);
                     av_opt_set_int(vEncCtx->priv_data, "bufsize", br * 2, 0);
                     av_opt_set       (vEncCtx->priv_data, "nal-hrd", "cbr", 0);
+                    if (useNvenc)
+                        av_opt_set(vEncCtx->priv_data, "rc", "cbr", 0);
                 }
             }
             if (outputCtx->oformat->flags & AVFMT_GLOBALHEADER)
@@ -180,6 +182,8 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                 snprintf(bufStr, sizeof(bufStr), "%dk", maxBitrate * 2);
                 av_dict_set(&encOpts, "bufsize", bufStr, 0);
                 av_dict_set(&encOpts, "nal-hrd", "cbr", 0);
+                if (useNvenc)
+                    av_dict_set(&encOpts, "rc", "cbr", 0);
             }
             if (avcodec_open2(vEncCtx, vEnc, &encOpts) < 0) {
                 DebugLog("Failed to open H.264 encoder", true);

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -151,8 +151,17 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
             vEncCtx->pix_fmt = AV_PIX_FMT_YUV420P;
             vEncCtx->max_b_frames = 2;
             vEncCtx->gop_size = 12;
-            if (maxBitrate > 0)
-                vEncCtx->bit_rate = maxBitrate * 1000;
+            if (maxBitrate > 0) {
+                int br = maxBitrate * 1000;
+                vEncCtx->bit_rate      = br;
+                vEncCtx->rc_max_rate   = br;
+                vEncCtx->rc_min_rate   = br;
+                vEncCtx->rc_buffer_size= br;
+                if (vEncCtx->priv_data) {
+                    av_opt_set_int(vEncCtx->priv_data, "bitrate", br, 0);
+                    av_opt_set_int(vEncCtx->priv_data, "b", br, 0);
+                }
+            }
             if (outputCtx->oformat->flags & AVFMT_GLOBALHEADER)
                 vEncCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
             AVDictionary* encOpts = nullptr;

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -155,31 +155,22 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                 int br = maxBitrate * 1000;
                 vEncCtx->bit_rate       = br;
                 vEncCtx->rc_max_rate    = br;
-                vEncCtx->rc_min_rate    = br;
                 vEncCtx->rc_buffer_size = br * 2;
             }
             if (outputCtx->oformat->flags & AVFMT_GLOBALHEADER)
                 vEncCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
             AVDictionary* encOpts = nullptr;
             av_dict_set(&encOpts, "preset", "fast", 0);
+            if (useNvenc)
+                av_dict_set(&encOpts, "profile", "high", 0);
             if (maxBitrate > 0) {
                 char brStr[32];
                 snprintf(brStr, sizeof(brStr), "%dk", maxBitrate);
                 av_dict_set(&encOpts, "b", brStr, 0);
-                av_dict_set(&encOpts, "minrate", brStr, 0);
                 av_dict_set(&encOpts, "maxrate", brStr, 0);
                 char bufStr[32];
                 snprintf(bufStr, sizeof(bufStr), "%dk", maxBitrate * 2);
                 av_dict_set(&encOpts, "bufsize", bufStr, 0);
-                av_dict_set(&encOpts, "nal-hrd", "cbr", 0);
-                if (useNvenc) {
-                    av_dict_set(&encOpts, "rc", "cbr", 0);
-                    av_dict_set(&encOpts, "cbr", "1", 0);
-                    av_dict_set(&encOpts, "cbr_padding", "1", 0);
-                    av_dict_set(&encOpts, "strict_gop", "1", 0);
-                    av_dict_set(&encOpts, "profile", "high", 0);
-                    av_dict_set(&encOpts, "rc-lookahead", "0", 0);
-                }
             }
             if (avcodec_open2(vEncCtx, vEnc, &encOpts) < 0) {
                 DebugLog("Failed to open H.264 encoder", true);


### PR DESCRIPTION
## Summary
- improve bitrate handling when converting to H264

## Testing
- `cmake -S . -B build` *(fails: FFmpeg libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e94ea145c832fbcd8eb3af2474233