### PR TITLE
Synchronize video to audio clock

### DIFF
--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -68,6 +68,10 @@ bool AudioPlayer::Initialize() {
     if (FAILED(hr))
         return false;
 
+    hr = m_player->audioClient->GetService(__uuidof(IAudioClock), (void**)&m_player->audioClock);
+    if (FAILED(hr))
+        return false;
+
     m_player->audioInitialized = true;
     return true;
 }
@@ -85,6 +89,11 @@ void AudioPlayer::Cleanup() {
     {
         m_player->renderClient->Release();
         m_player->renderClient = nullptr;
+    }
+    if (m_player->audioClock)
+    {
+        m_player->audioClock->Release();
+        m_player->audioClock = nullptr;
     }
     if (m_player->audioClient)
     {

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cstring>
 #include <chrono>
+#include <cmath>
 
 VideoPlayer::VideoPlayer(HWND parent)
     : parentWindow(parent), formatContext(nullptr), codecContext(nullptr),

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -395,7 +395,7 @@ void VideoPlayer::PlaybackThreadFunction()
         double audioTime = GetCurrentAudioTime();
 
         // Fallback to wall clock time until audio clock begins advancing
-        if (audioTime <= 0.0)
+        if (audioTime < 1e-6)
         {
             audioTime = std::chrono::duration<double>(
                 std::chrono::high_resolution_clock::now() - wallClockStart).count();

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -388,9 +388,18 @@ void VideoPlayer::SetMasterVolume(float volume)
 void VideoPlayer::PlaybackThreadFunction()
 {
     const double threshold = 0.02; // 20ms tolerance
+    auto wallClockStart = std::chrono::high_resolution_clock::now();
     while (playbackThreadRunning)
     {
         double audioTime = GetCurrentAudioTime();
+
+        // Fallback to wall clock time until audio clock begins advancing
+        if (audioTime <= 0.0)
+        {
+            audioTime = std::chrono::duration<double>(
+                std::chrono::high_resolution_clock::now() - wallClockStart).count();
+        }
+
         double targetPts = audioTime;
 
         while (currentPts < targetPts - threshold && playbackThreadRunning)

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -108,6 +108,7 @@ public:
     IMMDevice *audioDevice;
     IAudioClient *audioClient;
     IAudioRenderClient *renderClient;
+    IAudioClock *audioClock;
     WAVEFORMATEX *audioFormat;
     UINT32 bufferFrameCount;
     bool audioInitialized;
@@ -151,6 +152,7 @@ public:
 
     double GetDuration() const;
     double GetCurrentTime() const;
+    double GetCurrentAudioTime() const;
     int64_t GetCurrentFrame() const { return currentFrame; }
     int64_t GetTotalFrames() const { return totalFrames; }
 


### PR DESCRIPTION
## Summary
- track WASAPI playback position using `IAudioClock`
- expose `GetCurrentAudioTime` in the player
- sync video frames to the audio clock inside `PlaybackThreadFunction`

## Testing
- `cmake -S . -B build` *(fails: AVCODEC_LIBRARY NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686ec52178ac832f812c2df2ff65e3c0