### PR TITLE
Add Backblaze B2 upload option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,12 +62,22 @@ find_library(SWRESAMPLE_LIBRARY
     NO_DEFAULT_PATH
 )
 
+find_path(CURL_INCLUDE_DIR
+    NAMES curl/curl.h
+    PATHS ${FFMPEG_ROOT}/include
+    NO_DEFAULT_PATH)
+find_library(CURL_LIBRARY
+    NAMES libcurl_a libcurl
+    PATHS ${FFMPEG_ROOT}/lib
+    NO_DEFAULT_PATH)
+
 # Create the executable
 add_executable(VideoEditor WIN32
     src/main.cpp src/window_proc.cpp src/ui_controls.cpp src/file_handling.cpp src/ui_updates.cpp src/timeline.cpp src/editing.cpp src/utils.cpp src/video_decoder.cpp src/audio_player.cpp src/video_renderer.cpp src/video_cutter.cpp
     src/video_player.cpp
     src/options_window.cpp
     src/progress_window.cpp
+    src/b2_upload.cpp
 )
 
 # Headers live in src/
@@ -76,6 +86,9 @@ target_include_directories(VideoEditor PRIVATE src)
 # Include FFmpeg headers
 if(FFMPEG_INCLUDE_DIR)
     target_include_directories(VideoEditor PRIVATE ${FFMPEG_INCLUDE_DIR})
+endif()
+if(CURL_INCLUDE_DIR)
+    target_include_directories(VideoEditor PRIVATE ${CURL_INCLUDE_DIR})
 endif()
 
 # Link libraries
@@ -114,6 +127,7 @@ target_link_libraries(VideoEditor PRIVATE
     ${AVUTIL_LIBRARY}
     ${SWSCALE_LIBRARY}
     ${SWRESAMPLE_LIBRARY}
+    ${CURL_LIBRARY}
     ${FFMPEG_EXTRA_LIBS}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Define UNICODE for Windows API calls
 add_compile_definitions(UNICODE _UNICODE)
 
-# Set FFmpeg path - UPDATE THIS PATH to where you extracted FFmpeg
-set(FFMPEG_ROOT "C:/Program Files/ffmpeg" CACHE PATH "Path to FFmpeg")
+# Set the vcpkg installation path
+# Set FFmpeg path to vcpkg installation
+set(FFMPEG_ROOT "C:/tools/vcpkg/installed/x64-windows-static" CACHE PATH "Path to FFmpeg vcpkg installation")
 
 # Find FFmpeg libraries
-find_path(FFMPEG_INCLUDE_DIR 
+find_path(FFMPEG_INCLUDE_DIR
     NAMES libavcodec/avcodec.h
     PATHS ${FFMPEG_ROOT}/include
     NO_DEFAULT_PATH
@@ -62,14 +63,18 @@ find_library(SWRESAMPLE_LIBRARY
     NO_DEFAULT_PATH
 )
 
+# Find packages
 find_path(CURL_INCLUDE_DIR
     NAMES curl/curl.h
-    PATHS ${FFMPEG_ROOT}/include
-    NO_DEFAULT_PATH)
+    PATHS C:/tools/vcpkg/installed/x64-windows-static/include
+    NO_DEFAULT_PATH
+)
+
 find_library(CURL_LIBRARY
-    NAMES libcurl_a libcurl
-    PATHS ${FFMPEG_ROOT}/lib
-    NO_DEFAULT_PATH)
+    NAMES libcurl
+    PATHS C:/tools/vcpkg/installed/x64-windows-static/lib
+    NO_DEFAULT_PATH
+)
 
 # Create the executable
 add_executable(VideoEditor WIN32
@@ -83,10 +88,10 @@ add_executable(VideoEditor WIN32
 # Headers live in src/
 target_include_directories(VideoEditor PRIVATE src)
 
-# Include FFmpeg headers
 if(FFMPEG_INCLUDE_DIR)
     target_include_directories(VideoEditor PRIVATE ${FFMPEG_INCLUDE_DIR})
 endif()
+
 if(CURL_INCLUDE_DIR)
     target_include_directories(VideoEditor PRIVATE ${CURL_INCLUDE_DIR})
 endif()
@@ -122,12 +127,14 @@ target_link_libraries(VideoEditor PRIVATE
     mf
     mfuuid
     strmiids
+    crypt32
+    advapi32
+    ${CURL_LIBRARY}
     ${AVCODEC_LIBRARY}
     ${AVFORMAT_LIBRARY}
     ${AVUTIL_LIBRARY}
     ${SWSCALE_LIBRARY}
     ${SWRESAMPLE_LIBRARY}
-    ${CURL_LIBRARY}
     ${FFMPEG_EXTRA_LIBS}
 )
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All source files now reside under the `src/` directory to keep the project organ
 - **Codec Options**: Copy video/audio codecs for a fast cut or convert to H.264
 - **Bitrate or Target Size**: When converting to H.264 you can either set a bitrate or specify a desired final size; only the chosen option is shown
 - **Progress Window**: A small window shows export progress in real time
+- **Optional B2 Upload**: When credentials are configured the exported file is uploaded to Backblaze B2 automatically and the download URL is shown
 
 ## Technical Implementation
 
@@ -86,6 +87,7 @@ single `VideoEditor.exe` that does not need FFmpeg DLLs at runtime.
       additional codec features if desired:
       ```
       vcpkg install ffmpeg[dav1d,openh264,x264,x265,mp3lame,fdk-aac,opus,zlib,ffmpeg]:x64-windows-static
+      vcpkg install curl[core,sspi,ssl,schannel,non-http]:x64-windows-static
       ```
    2. Configure CMake pointing `FFMPEG_ROOT` to the vcpkg installation and
       enabling static linking:
@@ -139,6 +141,9 @@ using `-FFmpegPath`.
 3. **Track Volume**: Adjust the "Track Volume" slider for the selected track
 4. **Master Volume**: Use the "Master Volume" slider to control overall audio level
 
+### Backblaze Settings
+Open **Options** and click **B2 Settings** to enter your Backblaze account credentials. Enable *Auto upload* to have videos uploaded automatically after export.
+
 ### Audio Track Features
 - **Multiple Tracks**: All audio tracks play simultaneously by default
 - **Individual Control**: Each track can be muted or have its volume adjusted independently
@@ -161,6 +166,11 @@ The application supports all audio formats that FFmpeg can decode, including:
 - Low-latency audio output using WASAPI shared mode
 - Efficient audio mixing with minimal CPU overhead
 - Automatic format conversion handles different audio specifications
+
+### Backblaze B2 Upload
+Configure your B2 credentials under **Options > B2 Settings**. When `Auto upload`
+is enabled the exported video is automatically uploaded to Backblaze B2 and the
+download URL is shown after completion.
 
 ## Troubleshooting
 

--- a/run.ps1
+++ b/run.ps1
@@ -132,13 +132,17 @@ if (-not $Static.IsPresent) {
 if ($Static.IsPresent) {
     $required = @(
         "$FFmpegPath\include\libavcodec\avcodec.h",
-        "$FFmpegPath\lib\avcodec.lib"
+        "$FFmpegPath\lib\avcodec.lib",
+        "$FFmpegPath\include\curl\curl.h",
+        "$FFmpegPath\lib\libcurl_a.lib"
     )
 } else {
     $required = @(
         "$FFmpegPath\include\libavcodec\avcodec.h",
         "$FFmpegPath\lib\avcodec.lib",
-        "$FFmpegPath\bin\ffmpeg.exe"
+        "$FFmpegPath\bin\ffmpeg.exe",
+        "$FFmpegPath\include\curl\curl.h",
+        "$FFmpegPath\lib\libcurl.lib"
     )
 }
 

--- a/run.ps1
+++ b/run.ps1
@@ -134,7 +134,7 @@ if ($Static.IsPresent) {
         "$FFmpegPath\include\libavcodec\avcodec.h",
         "$FFmpegPath\lib\avcodec.lib",
         "$FFmpegPath\include\curl\curl.h",
-        "$FFmpegPath\lib\libcurl_a.lib"
+        "$FFmpegPath\lib\libcurl.lib"
     )
 } else {
     $required = @(
@@ -148,21 +148,24 @@ if ($Static.IsPresent) {
 
 foreach ($p in $required) {
     if (-not (Test-Path $p)) {
-        Write-Host "ERROR: No se encontró FFmpeg en: $p" -ForegroundColor Red
-        Write-Host "Asegúrate de descargar el paquete 'dev' y extraerlo correctamente." -ForegroundColor Yellow
+        Write-Host "ERROR: No se encontró un componente requerido en: $p" -ForegroundColor Red
+        Write-Host "Asegúrate de que las librerías (FFmpeg, curl, etc.) están instaladas con vcpkg y la ruta es correcta." -ForegroundColor Yellow
         exit 1
     }
 }
 Write-Host "FFmpeg validado en: $FFmpegPath" -ForegroundColor Green
 
+$env:CMAKE_TOOLCHAIN_FILE = "C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
+Write-Host "Usando vcpkg toolchain: $env:CMAKE_TOOLCHAIN_FILE" -ForegroundColor Cyan
+
 # 5) Configurar/reconfigurar CMake
 $staticFlag = if ($Static.IsPresent) { "ON" } else { "OFF" }
 if (-not (Test-Path ".\build")) {
     Write-Host "Configurando CMake..." -ForegroundColor Yellow
-    cmake -S . -B build -DFFMPEG_ROOT="$FFmpegPath" -DUSE_STATIC_FFMPEG=$staticFlag
+    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag
 } else {
     Write-Host "Reconfigurando CMake con nuevos parámetros..." -ForegroundColor Yellow
-    cmake -S . -B build -DFFMPEG_ROOT="$FFmpegPath" -DUSE_STATIC_FFMPEG=$staticFlag
+    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag
 }
 if ($LASTEXITCODE -ne 0) { Write-Error "Fallo la configuración de CMake."; exit 1 }
 

--- a/src/b2_upload.cpp
+++ b/src/b2_upload.cpp
@@ -1,0 +1,111 @@
+#include "b2_upload.h"
+#include "options_window.h"
+#include <curl/curl.h>
+#include <string>
+
+static size_t WriteCB(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    std::string* out = static_cast<std::string*>(userdata);
+    out->append(ptr, size * nmemb);
+    return size * nmemb;
+}
+
+static std::string Narrow(const std::wstring& w) {
+    int sz = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    std::string s(sz - 1, 0);
+    WideCharToMultiByte(CP_UTF8, 0, w.c_str(), -1, s.data(), sz, nullptr, nullptr);
+    return s;
+}
+
+static bool ExtractJson(const std::string& json, const std::string& key, std::string& value) {
+    size_t pos = json.find("\"" + key + "\"");
+    if (pos == std::string::npos) return false;
+    pos = json.find(':', pos);
+    if (pos == std::string::npos) return false;
+    pos = json.find('"', pos);
+    if (pos == std::string::npos) return false;
+    size_t end = json.find('"', pos + 1);
+    if (end == std::string::npos) return false;
+    value = json.substr(pos + 1, end - pos - 1);
+    return true;
+}
+
+bool UploadToB2(const std::wstring& filePath, std::string& outUrl) {
+    if (g_b2KeyId.empty() || g_b2AppKey.empty() || g_b2BucketId.empty() || g_b2BucketName.empty())
+        return false;
+
+    CURL* curl = curl_easy_init();
+    if (!curl) return false;
+
+    std::string response;
+    curl_easy_setopt(curl, CURLOPT_URL, "https://api.backblazeb2.com/b2api/v2/b2_authorize_account");
+    std::string creds = Narrow(g_b2KeyId) + ":" + Narrow(g_b2AppKey);
+    curl_easy_setopt(curl, CURLOPT_USERPWD, creds.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCB);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    CURLcode res = curl_easy_perform(curl);
+    if (res != CURLE_OK) { curl_easy_cleanup(curl); return false; }
+
+    std::string authToken, apiUrl, downloadUrl;
+    if (!ExtractJson(response, "authorizationToken", authToken) ||
+        !ExtractJson(response, "apiUrl", apiUrl) ||
+        !ExtractJson(response, "downloadUrl", downloadUrl)) {
+        curl_easy_cleanup(curl);
+        return false;
+    }
+
+    response.clear();
+    struct curl_slist* hdrs = nullptr;
+    std::string authHeader = "Authorization: " + authToken;
+    hdrs = curl_slist_append(hdrs, authHeader.c_str());
+    std::string postData = std::string("{\"bucketId\":\"") + Narrow(g_b2BucketId) + "\"}";
+    curl_easy_setopt(curl, CURLOPT_URL, (apiUrl + "/b2api/v2/b2_get_upload_url").c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postData.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, postData.size());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCB);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    res = curl_easy_perform(curl);
+    curl_slist_free_all(hdrs);
+    if (res != CURLE_OK) { curl_easy_cleanup(curl); return false; }
+
+    std::string uploadUrl, uploadAuth;
+    if (!ExtractJson(response, "uploadUrl", uploadUrl) ||
+        !ExtractJson(response, "authorizationToken", uploadAuth)) {
+        curl_easy_cleanup(curl);
+        return false;
+    }
+
+    FILE* fp = _wfopen(filePath.c_str(), L"rb");
+    if (!fp) { curl_easy_cleanup(curl); return false; }
+    fseek(fp, 0, SEEK_END);
+    long fsz = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+
+    std::wstring wname = filePath.substr(filePath.find_last_of(L"/\\") + 1);
+    std::string name = Narrow(wname);
+    char* esc = curl_easy_escape(curl, name.c_str(), 0);
+
+    hdrs = nullptr;
+    hdrs = curl_slist_append(hdrs, ("Authorization: " + uploadAuth).c_str());
+    hdrs = curl_slist_append(hdrs, (std::string("X-Bz-File-Name: ") + esc).c_str());
+    hdrs = curl_slist_append(hdrs, "Content-Type: b2/x-auto");
+    hdrs = curl_slist_append(hdrs, "X-Bz-Content-Sha1: do_not_verify");
+
+    curl_easy_setopt(curl, CURLOPT_URL, uploadUrl.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(curl, CURLOPT_READDATA, fp);
+    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsz);
+    response.clear();
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCB);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    res = curl_easy_perform(curl);
+    curl_slist_free_all(hdrs);
+    curl_free(esc);
+    fclose(fp);
+    if (res != CURLE_OK) { curl_easy_cleanup(curl); return false; }
+
+    outUrl = downloadUrl + "/file/" + Narrow(g_b2BucketName) + "/" + name;
+    curl_easy_cleanup(curl);
+    return true;
+}

--- a/src/b2_upload.h
+++ b/src/b2_upload.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+#include <windows.h>
+
+bool UploadToB2(const std::wstring& filePath, std::string& outUrl);

--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -4,6 +4,8 @@
 #include "progress_window.h"
 #include <commdlg.h>
 #include <thread>
+#include <string>
+#include "b2_upload.h"
 
 // Forward declarations
 void UpdateCutInfoLabel(HWND hwnd);
@@ -14,6 +16,9 @@ extern VideoPlayer *g_videoPlayer;
 extern double g_cutStartTime, g_cutEndTime;
 extern HWND g_hStatusText, g_hProgressBar;
 extern bool g_useNvenc;
+extern bool g_autoUpload;
+std::wstring g_uploadedUrl;
+bool g_uploadSuccess = false;
 bool g_lastOperationWasExport = false;
 
 void OnSetStartClicked(HWND hwnd)
@@ -171,9 +176,20 @@ void OnExportClicked(HWND hwnd)
         ShowProgressWindow(hwnd);
         std::wstring outFile = szFile;
         std::thread([hwnd, outFile, mergeAudio, convertH264, bitrate, startTime, endTime]() {
+            g_uploadSuccess = false;
+            g_uploadedUrl.clear();
             bool ok = g_videoPlayer->CutVideo(outFile, startTime, endTime,
                                              mergeAudio, convertH264, g_useNvenc,
                                              bitrate, g_hProgressBar, &g_cancelExport);
+            if (ok && g_autoUpload) {
+                std::string url;
+                if (UploadToB2(outFile, url)) {
+                    int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+                    g_uploadedUrl.assign(sz - 1, 0);
+                    MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_uploadedUrl.data(), sz);
+                    g_uploadSuccess = true;
+                }
+            }
             PostMessage(hwnd, (WM_APP + 1), ok ? 1 : 0, 0);
         }).detach();
     }

--- a/src/editing.h
+++ b/src/editing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <windows.h>
+#include <string>
 
 void OnSetStartClicked(HWND hwnd);
 void OnSetEndClicked(HWND hwnd);
@@ -8,3 +9,5 @@ void OnCutClicked(HWND hwnd);
 void OnExportClicked(HWND hwnd);
 
 extern bool g_lastOperationWasExport;
+extern bool g_uploadSuccess;
+extern std::wstring g_uploadedUrl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
     owc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
     RegisterClass(&owc);
 
+    WNDCLASS b2c = {};
+    b2c.lpfnWndProc = B2ConfigProc;
+    b2c.hInstance = hInstance;
+    b2c.lpszClassName = L"B2ConfigClass";
+    b2c.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    b2c.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    RegisterClass(&b2c);
+
     WNDCLASS pwc = {};
     pwc.lpfnWndProc = ProgressProc;
     pwc.hInstance = hInstance;

--- a/src/options_window.cpp
+++ b/src/options_window.cpp
@@ -8,6 +8,11 @@ static HWND g_hOptionsWnd = nullptr;
 // Global option variables
 bool g_useNvenc = false;
 bool g_logToFile = true;
+std::wstring g_b2KeyId;
+std::wstring g_b2AppKey;
+std::wstring g_b2BucketId;
+std::wstring g_b2BucketName;
+bool g_autoUpload = false;
 
 // Load settings from Windows registry
 void LoadSettings()
@@ -20,6 +25,23 @@ void LoadSettings()
         size = sizeof(val);
         if (RegQueryValueExW(hKey, L"EnableLogFile", nullptr, nullptr, (LPBYTE)&val, &size) == ERROR_SUCCESS)
             g_logToFile = (val != 0);
+
+        wchar_t buf[256];
+        DWORD sz = sizeof(buf);
+        if (RegQueryValueExW(hKey, L"B2KeyId", nullptr, nullptr, (LPBYTE)buf, &sz) == ERROR_SUCCESS)
+            g_b2KeyId = buf;
+        sz = sizeof(buf);
+        if (RegQueryValueExW(hKey, L"B2AppKey", nullptr, nullptr, (LPBYTE)buf, &sz) == ERROR_SUCCESS)
+            g_b2AppKey = buf;
+        sz = sizeof(buf);
+        if (RegQueryValueExW(hKey, L"B2BucketId", nullptr, nullptr, (LPBYTE)buf, &sz) == ERROR_SUCCESS)
+            g_b2BucketId = buf;
+        sz = sizeof(buf);
+        if (RegQueryValueExW(hKey, L"B2BucketName", nullptr, nullptr, (LPBYTE)buf, &sz) == ERROR_SUCCESS)
+            g_b2BucketName = buf;
+        sz = sizeof(DWORD); val = 0;
+        if (RegQueryValueExW(hKey, L"AutoUpload", nullptr, nullptr, (LPBYTE)&val, &sz) == ERROR_SUCCESS)
+            g_autoUpload = val != 0;
         RegCloseKey(hKey);
     }
 }
@@ -33,6 +55,12 @@ void SaveSettings()
         RegSetValueExW(hKey, L"UseNvenc", 0, REG_DWORD, (const BYTE*)&val, sizeof(val));
         val = g_logToFile ? 1 : 0;
         RegSetValueExW(hKey, L"EnableLogFile", 0, REG_DWORD, (const BYTE*)&val, sizeof(val));
+        RegSetValueExW(hKey, L"B2KeyId", 0, REG_SZ, (const BYTE*)g_b2KeyId.c_str(), (DWORD)((g_b2KeyId.size()+1)*sizeof(wchar_t)));
+        RegSetValueExW(hKey, L"B2AppKey", 0, REG_SZ, (const BYTE*)g_b2AppKey.c_str(), (DWORD)((g_b2AppKey.size()+1)*sizeof(wchar_t)));
+        RegSetValueExW(hKey, L"B2BucketId", 0, REG_SZ, (const BYTE*)g_b2BucketId.c_str(), (DWORD)((g_b2BucketId.size()+1)*sizeof(wchar_t)));
+        RegSetValueExW(hKey, L"B2BucketName", 0, REG_SZ, (const BYTE*)g_b2BucketName.c_str(), (DWORD)((g_b2BucketName.size()+1)*sizeof(wchar_t)));
+        val = g_autoUpload ? 1 : 0;
+        RegSetValueExW(hKey, L"AutoUpload", 0, REG_DWORD, (const BYTE*)&val, sizeof(val));
         RegCloseKey(hKey);
     }
 }
@@ -46,7 +74,7 @@ void ShowOptionsWindow(HWND parent)
 
     g_hOptionsWnd = CreateWindowEx(0, L"OptionsClass", L"Options",
                                    WS_CAPTION | WS_POPUPWINDOW | WS_VISIBLE,
-                                   CW_USEDEFAULT, CW_USEDEFAULT, 220, 180,
+                                   CW_USEDEFAULT, CW_USEDEFAULT, 260, 200,
                                    parent, nullptr,
                                    (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(g_hOptionsWnd);
@@ -72,18 +100,24 @@ void ShowOptionsWindow(HWND parent)
     ApplyDarkTheme(hLib);
     ApplyDarkTheme(hNv);
     ApplyDarkTheme(hLog);
+    HWND hB2 = CreateWindow(L"BUTTON", L"B2 Settings",
+                            WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+                            10, 120, 100, 25, g_hOptionsWnd,
+                            (HMENU)ID_BUTTON_B2_CONFIG,
+                            (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
     HWND hOk = CreateWindow(L"BUTTON", L"OK",
                             WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
-                            30, 120, 70, 25, g_hOptionsWnd,
+                            120, 120, 60, 25, g_hOptionsWnd,
                             (HMENU)IDOK,
                             (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
     HWND hCancel = CreateWindow(L"BUTTON", L"Cancel",
                                 WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
-                                110, 120, 70, 25, g_hOptionsWnd,
+                                190, 120, 60, 25, g_hOptionsWnd,
                                 (HMENU)IDCANCEL,
                                 (HINSTANCE)GetWindowLongPtr(g_hOptionsWnd, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(hOk);
     ApplyDarkTheme(hCancel);
+    ApplyDarkTheme(hB2);
 
     SendMessage(hLib, BM_SETCHECK, g_useNvenc ? BST_UNCHECKED : BST_CHECKED, 0);
     SendMessage(hNv, BM_SETCHECK, g_useNvenc ? BST_CHECKED : BST_UNCHECKED, 0);
@@ -94,7 +128,9 @@ LRESULT CALLBACK OptionsProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     switch (msg) {
     case WM_COMMAND:
-        if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL) {
+        if (LOWORD(wParam) == ID_BUTTON_B2_CONFIG) {
+            ShowB2ConfigWindow(hwnd);
+        } else if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL) {
             HWND hNv = GetDlgItem(hwnd, ID_RADIO_ENCODER_NVENC);
             HWND hLog = GetDlgItem(hwnd, ID_CHECKBOX_ENABLE_LOG);
             g_useNvenc = SendMessage(hNv, BM_GETCHECK, 0, 0) == BST_CHECKED;
@@ -115,6 +151,127 @@ LRESULT CALLBACK OptionsProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         break;
     case WM_DESTROY:
         g_hOptionsWnd = nullptr;
+        break;
+    }
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+// ---------------- B2 Configuration Window -----------------
+
+static HWND g_hB2Wnd = nullptr;
+
+void ShowB2ConfigWindow(HWND parent)
+{
+    if (g_hB2Wnd) { SetForegroundWindow(g_hB2Wnd); return; }
+
+    g_hB2Wnd = CreateWindowEx(0, L"B2ConfigClass", L"Backblaze B2 Settings",
+                              WS_CAPTION | WS_POPUPWINDOW | WS_VISIBLE,
+                              CW_USEDEFAULT, CW_USEDEFAULT, 340, 230,
+                              parent, nullptr,
+                              (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(g_hB2Wnd);
+
+    CreateWindow(L"STATIC", L"Key ID:", WS_CHILD | WS_VISIBLE,
+                 10, 10, 100, 20, g_hB2Wnd, nullptr,
+                 (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+    HWND hKeyId = CreateWindow(L"EDIT", g_b2KeyId.c_str(),
+                               WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL,
+                               120, 10, 190, 20, g_hB2Wnd,
+                               (HMENU)ID_EDIT_B2_KEY_ID,
+                               (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+
+    CreateWindow(L"STATIC", L"App Key:", WS_CHILD | WS_VISIBLE,
+                 10, 40, 100, 20, g_hB2Wnd, nullptr,
+                 (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+    HWND hAppKey = CreateWindow(L"EDIT", g_b2AppKey.c_str(),
+                               WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL,
+                               120, 40, 190, 20, g_hB2Wnd,
+                               (HMENU)ID_EDIT_B2_APP_KEY,
+                               (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+
+    CreateWindow(L"STATIC", L"Bucket ID:", WS_CHILD | WS_VISIBLE,
+                 10, 70, 100, 20, g_hB2Wnd, nullptr,
+                 (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+    HWND hBucketId = CreateWindow(L"EDIT", g_b2BucketId.c_str(),
+                                 WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL,
+                                 120, 70, 190, 20, g_hB2Wnd,
+                                 (HMENU)ID_EDIT_B2_BUCKET_ID,
+                                 (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+
+    CreateWindow(L"STATIC", L"Bucket Name:", WS_CHILD | WS_VISIBLE,
+                 10, 100, 100, 20, g_hB2Wnd, nullptr,
+                 (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+    HWND hBucketName = CreateWindow(L"EDIT", g_b2BucketName.c_str(),
+                                   WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL,
+                                   120, 100, 190, 20, g_hB2Wnd,
+                                   (HMENU)ID_EDIT_B2_BUCKET_NAME,
+                                   (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+
+    HWND hAuto = CreateWindow(L"BUTTON", L"Auto upload after export",
+                              WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX,
+                              10, 130, 200, 20, g_hB2Wnd,
+                              (HMENU)ID_CHECKBOX_AUTO_UPLOAD,
+                              (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+
+    HWND hOk = CreateWindow(L"BUTTON", L"OK",
+                            WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
+                            70, 170, 80, 25, g_hB2Wnd,
+                            (HMENU)IDOK,
+                            (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+    HWND hCancel = CreateWindow(L"BUTTON", L"Cancel",
+                                WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+                                170, 170, 80, 25, g_hB2Wnd,
+                                (HMENU)IDCANCEL,
+                                (HINSTANCE)GetWindowLongPtr(g_hB2Wnd, GWLP_HINSTANCE), nullptr);
+
+    ApplyDarkTheme(hKeyId);
+    ApplyDarkTheme(hAppKey);
+    ApplyDarkTheme(hBucketId);
+    ApplyDarkTheme(hBucketName);
+    ApplyDarkTheme(hAuto);
+    ApplyDarkTheme(hOk);
+    ApplyDarkTheme(hCancel);
+
+    SendMessage(hAuto, BM_SETCHECK, g_autoUpload ? BST_CHECKED : BST_UNCHECKED, 0);
+}
+
+LRESULT CALLBACK B2ConfigProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg) {
+    case WM_COMMAND:
+        if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL) {
+            wchar_t buf[256];
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_KEY_ID), buf, 256);
+            g_b2KeyId = buf;
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_APP_KEY), buf, 256);
+            g_b2AppKey = buf;
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_BUCKET_ID), buf, 256);
+            g_b2BucketId = buf;
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_BUCKET_NAME), buf, 256);
+            g_b2BucketName = buf;
+            g_autoUpload = SendMessage(GetDlgItem(hwnd, ID_CHECKBOX_AUTO_UPLOAD), BM_GETCHECK, 0, 0) == BST_CHECKED;
+            SaveSettings();
+            DestroyWindow(hwnd);
+        }
+        break;
+    case WM_CLOSE:
+        {
+            wchar_t buf[256];
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_KEY_ID), buf, 256);
+            g_b2KeyId = buf;
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_APP_KEY), buf, 256);
+            g_b2AppKey = buf;
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_BUCKET_ID), buf, 256);
+            g_b2BucketId = buf;
+            GetWindowTextW(GetDlgItem(hwnd, ID_EDIT_B2_BUCKET_NAME), buf, 256);
+            g_b2BucketName = buf;
+            g_autoUpload = SendMessage(GetDlgItem(hwnd, ID_CHECKBOX_AUTO_UPLOAD), BM_GETCHECK, 0, 0) == BST_CHECKED;
+            SaveSettings();
+            DestroyWindow(hwnd);
+        }
+        break;
+    case WM_DESTROY:
+        g_hB2Wnd = nullptr;
         break;
     }
     return DefWindowProc(hwnd, msg, wParam, lParam);

--- a/src/options_window.h
+++ b/src/options_window.h
@@ -7,9 +7,26 @@
 #define ID_RADIO_ENCODER_LIBX264 1021
 #define ID_RADIO_ENCODER_NVENC  1022
 #define ID_CHECKBOX_ENABLE_LOG  1023
+#define ID_BUTTON_B2_CONFIG     1024
+
+// B2 config control identifiers
+#define ID_EDIT_B2_KEY_ID       2001
+#define ID_EDIT_B2_APP_KEY      2002
+#define ID_EDIT_B2_BUCKET_ID    2003
+#define ID_EDIT_B2_BUCKET_NAME  2004
+#define ID_CHECKBOX_AUTO_UPLOAD 2005
 
 extern bool g_useNvenc;
 extern bool g_logToFile;
+
+extern std::wstring g_b2KeyId;
+extern std::wstring g_b2AppKey;
+extern std::wstring g_b2BucketId;
+extern std::wstring g_b2BucketName;
+extern bool g_autoUpload;
+
+void ShowB2ConfigWindow(HWND parent);
+LRESULT CALLBACK B2ConfigProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 void ShowOptionsWindow(HWND parent);
 LRESULT CALLBACK OptionsProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/src/options_window.h
+++ b/src/options_window.h
@@ -2,6 +2,7 @@
 #define OPTIONS_WINDOW_H
 
 #include <windows.h>
+#include <string>
 
 // Option identifiers used in the options window
 #define ID_RADIO_ENCODER_LIBX264 1021

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -33,6 +33,9 @@ extern HWND g_hEditStartTime, g_hEditEndTime, g_hListBoxAudioTracks, g_hSliderTr
 extern double g_cutStartTime;
 extern double g_cutEndTime;
 extern bool g_lastOperationWasExport;
+extern bool g_uploadSuccess;
+extern std::wstring g_uploadedUrl;
+extern bool g_autoUpload;
 extern HBRUSH g_hbrBackground;
 extern HFONT g_hFont;
 extern COLORREF g_textColor;
@@ -269,7 +272,16 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             UINT flags;
             if (success)
             {
-                msg = g_lastOperationWasExport ? L"Video successfully exported." : L"Video successfully cut and saved.";
+                if (g_lastOperationWasExport && g_autoUpload) {
+                    std::wstring m = L"Video successfully exported.";
+                    if (g_uploadSuccess)
+                        m += L"\nUploaded to B2:\n" + g_uploadedUrl;
+                    else
+                        m += L"\nFailed to upload to B2.";
+                    msg = m.c_str();
+                } else {
+                    msg = g_lastOperationWasExport ? L"Video successfully exported." : L"Video successfully cut and saved.";
+                }
                 title = L"Success";
                 flags = MB_OK | MB_ICONINFORMATION;
             }


### PR DESCRIPTION
## Summary
- enable optional uploading of exported videos to Backblaze B2
- add new B2 settings dialog and persist credentials
- integrate libcurl and new upload helper
- add vcpkg `curl` dependency to build instructions and scripts
- update README with new instructions and feature description

## Testing
- `cmake -S . -B build` *(fails: The following variables are used in this project, but they are set to NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686efcf43098832f8a9e87bba056fac0