### PR TITLE
Fix B2 upload and support auto-upload for cuts

### DIFF
--- a/src/b2_upload.cpp
+++ b/src/b2_upload.cpp
@@ -94,6 +94,7 @@ bool UploadToB2(const std::wstring& filePath, std::string& outUrl) {
     curl_easy_setopt(curl, CURLOPT_URL, uploadUrl.c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
     curl_easy_setopt(curl, CURLOPT_READDATA, fp);
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsz);
     response.clear();

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -272,8 +272,8 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             UINT flags;
             if (success)
             {
-                if (g_lastOperationWasExport && g_autoUpload) {
-                    std::wstring m = L"Video successfully exported.";
+                if (g_autoUpload) {
+                    std::wstring m = g_lastOperationWasExport ? L"Video successfully exported." : L"Video successfully cut and saved.";
                     if (g_uploadSuccess)
                         m += L"\nUploaded to B2:\n" + g_uploadedUrl;
                     else


### PR DESCRIPTION
## Summary
- support uploading to Backblaze B2 when cutting a clip
- send upload requests via POST instead of PUT so large files upload correctly
- show upload status after both export and cut operations

## Testing
- `cmake ..` *(fails: AVCODEC_LIBRARY NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68700eb77040832f972919cc22ee10a5