### PR TITLE
Fix dynamic build path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Define UNICODE for Windows API calls
 add_compile_definitions(UNICODE _UNICODE)
 
-# Set the vcpkg installation path
-# Set FFmpeg path to vcpkg installation
-set(FFMPEG_ROOT "C:/tools/vcpkg/installed/x64-windows-static" CACHE PATH "Path to FFmpeg vcpkg installation")
+# Default path to the shared FFmpeg binaries
+set(FFMPEG_ROOT "C:/Program Files/ffmpeg" CACHE PATH "Path to FFmpeg installation")
 
 # Find FFmpeg libraries
 find_path(FFMPEG_INCLUDE_DIR

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ single `VideoEditor.exe` that does not need FFmpeg DLLs at runtime.
 
 1. **Using the prebuilt shared FFmpeg binaries** (default)
    1. Extract FFmpeg to `C:/Program Files/ffmpeg` (or set `FFMPEG_ROOT` when
-      configuring CMake).
+      configuring CMake). This is now the default `FFMPEG_ROOT` value.
    2. Create a build directory: `mkdir build && cd build`
    3. Generate the project: `cmake ..`
    4. Build: `cmake --build . --config Release`
@@ -111,6 +111,8 @@ Alternatively you can use the provided `run.ps1` script:
 ```powershell
 ./run.ps1 -Static
 ```
+Run without `-Static` to build against the shared FFmpeg DLLs. The script
+passes the chosen path to CMake using `FFMPEG_ROOT`.
 
 When `-Static` is used the script looks for FFmpeg in
 `C:\tools\vcpkg\installed\x64-windows-static` unless another path is passed

--- a/run.ps1
+++ b/run.ps1
@@ -162,10 +162,10 @@ Write-Host "Usando vcpkg toolchain: $env:CMAKE_TOOLCHAIN_FILE" -ForegroundColor 
 $staticFlag = if ($Static.IsPresent) { "ON" } else { "OFF" }
 if (-not (Test-Path ".\build")) {
     Write-Host "Configurando CMake..." -ForegroundColor Yellow
-    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag
+    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag "-DFFMPEG_ROOT=$FFmpegPath"
 } else {
     Write-Host "Reconfigurando CMake con nuevos parámetros..." -ForegroundColor Yellow
-    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag
+    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag "-DFFMPEG_ROOT=$FFmpegPath"
 }
 if ($LASTEXITCODE -ne 0) { Write-Error "Fallo la configuración de CMake."; exit 1 }
 


### PR DESCRIPTION
## Summary
- default `FFMPEG_ROOT` to the shared FFmpeg folder
- pass chosen FFmpeg path from `run.ps1` to CMake
- document default path and dynamic build behaviour

## Testing
- `cmake -B build -S .` *(fails: cannot find FFmpeg libraries)*

------
https://chatgpt.com/codex/tasks/task_e_687135d6f368832fb0d913ba84c33177