### PR TITLE
Add zlib detection for vendored curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ if(NOT USE_STATIC_FFMPEG)
         message(FATAL_ERROR "❌ zlib.lib no existe en ${CURL_ROOT}/lib")
     endif()
     message(STATUS ">> Usando zlib vendorizado: ${CURL_ROOT}/lib/zlib.lib")
+elseif(USE_STATIC_FFMPEG)
+    # Si es estático, usamos la zlib de FFmpeg
+    set(VENDOR_ZLIB_INCLUDE_DIR "${FFMPEG_ROOT}/include")
+    set(VENDOR_ZLIB_LIBRARIES "${FFMPEG_ROOT}/lib/zlib.lib")
+    add_library(VENDOR_ZLIB INTERFACE)
+    target_include_directories(VENDOR_ZLIB INTERFACE ${VENDOR_ZLIB_INCLUDE_DIR})
+    target_link_libraries(VENDOR_ZLIB INTERFACE ${VENDOR_ZLIB_LIBRARIES})
+    message(STATUS ">> Usando zlib de FFmpeg: ${VENDOR_ZLIB_LIBRARIES}")
 endif()
 
 # ==== EJECUTABLE Y CÓDIGO FUENTE ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,10 @@ find_library(CURL_LIBRARY
         C:/tools/vcpkg/installed/x64-windows-static/lib
     NO_DEFAULT_PATH
 )
+if(NOT CURL_LIBRARY AND EXISTS "${CURL_ROOT}/lib/libcurl.lib")
+    set(CURL_LIBRARY "${CURL_ROOT}/lib/libcurl.lib" CACHE FILEPATH "Curl library" FORCE)
+    message(STATUS "Using vendored libcurl: ${CURL_LIBRARY}")
+endif()
 
 if(NOT USE_STATIC_FFMPEG)
     # Vendored libcurl depends on zlib when linking dynamically. Import it as a
@@ -91,7 +95,10 @@ if(NOT USE_STATIC_FFMPEG)
     if(EXISTS "${_curl_zlib}")
         message(STATUS "Found curl zlib: ${_curl_zlib}")
         add_library(CURL_ZLIB STATIC IMPORTED GLOBAL)
-        set_target_properties(CURL_ZLIB PROPERTIES IMPORTED_LOCATION "${_curl_zlib}")
+        set_target_properties(CURL_ZLIB PROPERTIES
+            IMPORTED_LOCATION "${_curl_zlib}"
+            IMPORTED_LOCATION_RELEASE "${_curl_zlib}"
+        )
     else()
         message(FATAL_ERROR "curl zlib library not found: ${_curl_zlib}")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,12 +85,15 @@ find_library(CURL_LIBRARY
 )
 
 if(NOT USE_STATIC_FFMPEG)
-    # Vendored libcurl requires zlib when linking dynamically
-    set(CURL_ZLIB_LIBRARY "${CURL_ROOT}/lib/zlib.lib" CACHE FILEPATH "Path to zlib for vendored curl")
-    if(EXISTS "${CURL_ZLIB_LIBRARY}")
-        message(STATUS "Found curl zlib: ${CURL_ZLIB_LIBRARY}")
+    # Vendored libcurl depends on zlib when linking dynamically. Import it as a
+    # separate library so MSBuild links it correctly.
+    set(_curl_zlib "${CURL_ROOT}/lib/zlib.lib")
+    if(EXISTS "${_curl_zlib}")
+        message(STATUS "Found curl zlib: ${_curl_zlib}")
+        add_library(CURL_ZLIB STATIC IMPORTED GLOBAL)
+        set_target_properties(CURL_ZLIB PROPERTIES IMPORTED_LOCATION "${_curl_zlib}")
     else()
-        message(FATAL_ERROR "curl zlib library not found: ${CURL_ZLIB_LIBRARY}")
+        message(FATAL_ERROR "curl zlib library not found: ${_curl_zlib}")
     endif()
 endif()
 
@@ -157,7 +160,7 @@ target_link_libraries(VideoEditor PRIVATE
 )
 
 if(NOT USE_STATIC_FFMPEG)
-    target_link_libraries(VideoEditor PRIVATE ${CURL_ZLIB_LIBRARY})
+    target_link_libraries(VideoEditor PRIVATE CURL_ZLIB)
 endif()
 
 # Copy FFmpeg DLLs when linking dynamically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,183 +1,141 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Ensure newer policy for MSVC runtime selection when available
+# Política para runtime MSVC
 if(POLICY CMP0091)
     cmake_policy(SET CMP0091 NEW)
 endif()
+
 project(VideoEditor CXX)
 
-# Option to link FFmpeg statically
-option(USE_STATIC_FFMPEG "Link FFmpeg statically" OFF)
+if(USE_STATIC_FFMPEG)
+    message(STATUS "🔗 Enlazando FFmpeg estáticamente")
+endif()
+if(NOT USE_STATIC_FFMPEG)
+    message(STATUS "🔗 Enlazando FFmpeg dinámicamente")
+endif()
 
+# Si usas MSVC y FFmpeg estático, forzamos runtime estático y LTO
 if(MSVC AND USE_STATIC_FFMPEG)
-    # Link the MSVC runtime statically when building a portable executable
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    # Enable link-time optimization to reduce overhead in the static build
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
 endif()
 
+# C++17 obligatorio
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Define UNICODE for Windows API calls
+# UNICODE en Win32
 add_compile_definitions(UNICODE _UNICODE)
 
-# Default path to the shared FFmpeg binaries
+# Rutas por defecto (puedes sobreescribir con -DFFMPEG_ROOT=... o -DCURL_ROOT=...)
 set(FFMPEG_ROOT "C:/Program Files/ffmpeg" CACHE PATH "Path to FFmpeg installation")
+set(CURL_ROOT   "${CMAKE_SOURCE_DIR}/vendor/libcurl" CACHE PATH "Path to libcurl installation")
 
-# Default path to the vendored libcurl
-set(CURL_ROOT "${CMAKE_SOURCE_DIR}/vendor/libcurl" CACHE PATH "Path to libcurl installation")
-
-# Find FFmpeg libraries
+# ==== BUSCAR FFmpeg ====
 find_path(FFMPEG_INCLUDE_DIR
     NAMES libavcodec/avcodec.h
     PATHS ${FFMPEG_ROOT}/include
     NO_DEFAULT_PATH
 )
+find_library(AVCODEC_LIBRARY    NAMES avcodec    PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
+find_library(AVFORMAT_LIBRARY   NAMES avformat   PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
+find_library(AVUTIL_LIBRARY     NAMES avutil     PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
+find_library(SWSCALE_LIBRARY    NAMES swscale    PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
+find_library(SWRESAMPLE_LIBRARY NAMES swresample PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
 
-find_library(AVCODEC_LIBRARY
-    NAMES avcodec
-    PATHS ${FFMPEG_ROOT}/lib
-    NO_DEFAULT_PATH
-)
+message(STATUS ">> FFmpeg include: ${FFMPEG_INCLUDE_DIR}")
+message(STATUS ">> avcodec lib:    ${AVCODEC_LIBRARY}")
 
-find_library(AVFORMAT_LIBRARY
-    NAMES avformat
-    PATHS ${FFMPEG_ROOT}/lib
-    NO_DEFAULT_PATH
+# ==== IMPORTED TARGET: libcurl ====
+add_library(VENDOR_LIBCURL STATIC IMPORTED GLOBAL)
+set_target_properties(VENDOR_LIBCURL PROPERTIES
+    IMPORTED_LOCATION_DEBUG   "${CURL_ROOT}/lib/libcurl.lib"
+    IMPORTED_LOCATION_RELEASE "${CURL_ROOT}/lib/libcurl.lib"
+    INTERFACE_INCLUDE_DIRECTORIES "${CURL_ROOT}/include"
 )
-
-find_library(AVUTIL_LIBRARY
-    NAMES avutil
-    PATHS ${FFMPEG_ROOT}/lib
-    NO_DEFAULT_PATH
-)
-
-find_library(SWSCALE_LIBRARY
-    NAMES swscale
-    PATHS ${FFMPEG_ROOT}/lib
-    NO_DEFAULT_PATH
-)
-
-find_library(SWRESAMPLE_LIBRARY
-    NAMES swresample
-    PATHS ${FFMPEG_ROOT}/lib
-    NO_DEFAULT_PATH
-)
-
-# Find packages
-find_path(CURL_INCLUDE_DIR
-    NAMES curl/curl.h
-    PATHS
-        ${FFMPEG_ROOT}/include
-        ${CURL_ROOT}/include
-        C:/tools/vcpkg/installed/x64-windows-static/include
-    NO_DEFAULT_PATH
-)
-
-find_library(CURL_LIBRARY
-    NAMES libcurl
-    PATHS
-        ${FFMPEG_ROOT}/lib
-        ${CURL_ROOT}/lib
-        C:/tools/vcpkg/installed/x64-windows-static/lib
-    NO_DEFAULT_PATH
-)
-if(NOT CURL_LIBRARY AND EXISTS "${CURL_ROOT}/lib/libcurl.lib")
-    set(CURL_LIBRARY "${CURL_ROOT}/lib/libcurl.lib" CACHE FILEPATH "Curl library" FORCE)
-    message(STATUS "Using vendored libcurl: ${CURL_LIBRARY}")
+if(NOT EXISTS "${CURL_ROOT}/lib/libcurl.lib")
+    message(FATAL_ERROR "❌ libcurl.lib no existe en ${CURL_ROOT}/lib")
 endif()
+message(STATUS ">> Usando libcurl vendorizado: ${CURL_ROOT}/lib/libcurl.lib")
 
+# ==== IMPORTED TARGET: zlib (solo para build dinámico) ====
 if(NOT USE_STATIC_FFMPEG)
-    # Vendored libcurl depends on zlib when linking dynamically. Import it as a
-    # separate library so MSBuild links it correctly.
-    set(_curl_zlib "${CURL_ROOT}/lib/zlib.lib")
-    if(EXISTS "${_curl_zlib}")
-        message(STATUS "Found curl zlib: ${_curl_zlib}")
-        add_library(CURL_ZLIB STATIC IMPORTED GLOBAL)
-        set_target_properties(CURL_ZLIB PROPERTIES
-            IMPORTED_LOCATION "${_curl_zlib}"
-            IMPORTED_LOCATION_RELEASE "${_curl_zlib}"
-        )
-    else()
-        message(FATAL_ERROR "curl zlib library not found: ${_curl_zlib}")
+    add_library(VENDOR_ZLIB STATIC IMPORTED GLOBAL)
+    message(STATUS ">> Usando zlib vendorizado: ${CURL_ROOT}/lib/zlib.lib")
+    set_target_properties(VENDOR_ZLIB PROPERTIES
+        IMPORTED_LOCATION_DEBUG   "${CURL_ROOT}/lib/zlib.lib"
+        IMPORTED_LOCATION_RELEASE "${CURL_ROOT}/lib/zlib.lib"
+    )
+    if(NOT EXISTS "${CURL_ROOT}/lib/zlib.lib")
+        message(FATAL_ERROR "❌ zlib.lib no existe en ${CURL_ROOT}/lib")
     endif()
+    message(STATUS ">> Usando zlib vendorizado: ${CURL_ROOT}/lib/zlib.lib")
 endif()
 
-# Create the executable
+# ==== EJECUTABLE Y CÓDIGO FUENTE ====
 add_executable(VideoEditor WIN32
-    src/main.cpp src/window_proc.cpp src/ui_controls.cpp src/file_handling.cpp src/ui_updates.cpp src/timeline.cpp src/editing.cpp src/utils.cpp src/video_decoder.cpp src/audio_player.cpp src/video_renderer.cpp src/video_cutter.cpp
+    src/main.cpp
+    src/window_proc.cpp
+    src/ui_controls.cpp
+    src/file_handling.cpp
+    src/ui_updates.cpp
+    src/timeline.cpp
+    src/editing.cpp
+    src/utils.cpp
+    src/video_decoder.cpp
+    src/audio_player.cpp
+    src/video_renderer.cpp
+    src/video_cutter.cpp
     src/video_player.cpp
     src/options_window.cpp
     src/progress_window.cpp
     src/b2_upload.cpp
 )
 
-# Headers live in src/
-target_include_directories(VideoEditor PRIVATE src)
+# ==== DIRECTORIOS DE INCLUDES ====
+target_include_directories(VideoEditor PRIVATE
+    src
+    ${FFMPEG_INCLUDE_DIR}
+)
 
-if(FFMPEG_INCLUDE_DIR)
-    target_include_directories(VideoEditor PRIVATE ${FFMPEG_INCLUDE_DIR})
-endif()
+# ==== LIBS DE PLATAFORMA WINDOWS ====
+set(PLATFORM_LIBS
+    user32 gdi32 d2d1 comctl32 comdlg32 ole32 winmm
+    dwmapi uxtheme shell32 ws2_32 bcrypt secur32 mfplat
+    mf mfuuid strmiids crypt32 advapi32
+)
 
-if(CURL_INCLUDE_DIR)
-    target_include_directories(VideoEditor PRIVATE ${CURL_INCLUDE_DIR})
-endif()
-
-# Link libraries
-set(FFMPEG_EXTRA_LIBS "")
-if(USE_STATIC_FFMPEG)
-    # When linking the static variant from vcpkg, FFmpeg depends on several
-    # additional libraries (zlib, libxml2, libmp3lame, etc.).  Rather than
-    # hardcoding each one, gather all libraries in the FFmpeg lib folder and
-    # link them as well.  This prevents unresolved symbols when optional
-    # features are enabled.
-    file(GLOB _all_ffmpeg_libs "${FFMPEG_ROOT}/lib/*.lib")
-    list(FILTER _all_ffmpeg_libs EXCLUDE REGEX "avcodec|avformat|avutil|swscale|swresample")
-    set(FFMPEG_EXTRA_LIBS ${_all_ffmpeg_libs})
-endif()
-
-target_link_libraries(VideoEditor PRIVATE
-    user32
-    gdi32
-    d2d1
-    comctl32
-    comdlg32
-    ole32
-    winmm
-    dwmapi
-    uxtheme
-    shell32
-    ws2_32
-    bcrypt
-    secur32
-    mfplat
-    mf
-    mfuuid
-    strmiids
-    crypt32
-    advapi32
-    ${CURL_LIBRARY}
+# ==== LIBS DE FFMPEG ====
+set(FFMPEG_LIBS
     ${AVCODEC_LIBRARY}
     ${AVFORMAT_LIBRARY}
     ${AVUTIL_LIBRARY}
     ${SWSCALE_LIBRARY}
     ${SWRESAMPLE_LIBRARY}
-    ${FFMPEG_EXTRA_LIBS}
 )
-
-if(NOT USE_STATIC_FFMPEG)
-    target_link_libraries(VideoEditor PRIVATE CURL_ZLIB)
+if(USE_STATIC_FFMPEG)
+    # Enlazamos también todas las .lib extra en modo estático
+    file(GLOB _all_ffmpeg_libs "${FFMPEG_ROOT}/lib/*.lib")
+    list(FILTER _all_ffmpeg_libs EXCLUDE REGEX "avcodec|avformat|avutil|swscale|swresample")
+    list(APPEND FFMPEG_LIBS ${_all_ffmpeg_libs})
 endif()
 
-# Copy FFmpeg DLLs when linking dynamically
+# ==== LINKEO FINAL ====
+target_link_libraries(VideoEditor PRIVATE
+    ${PLATFORM_LIBS}
+    ${FFMPEG_LIBS}
+    VENDOR_LIBCURL
+    $<$<BOOL:NOT USE_STATIC_FFMPEG>:VENDOR_ZLIB>
+)
+
+# ==== COPIA DE DLLS DE FFMPEG (dinámico) ====
 if(WIN32 AND NOT USE_STATIC_FFMPEG)
     add_custom_command(TARGET VideoEditor POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avcodec-62.dll" "$<TARGET_FILE_DIR:VideoEditor>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avformat-62.dll" "$<TARGET_FILE_DIR:VideoEditor>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avutil-60.dll" "$<TARGET_FILE_DIR:VideoEditor>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/swscale-9.dll" "$<TARGET_FILE_DIR:VideoEditor>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avcodec-62.dll"   "$<TARGET_FILE_DIR:VideoEditor>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avformat-62.dll"  "$<TARGET_FILE_DIR:VideoEditor>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/avutil-60.dll"    "$<TARGET_FILE_DIR:VideoEditor>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/swscale-9.dll"    "$<TARGET_FILE_DIR:VideoEditor>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${FFMPEG_ROOT}/bin/swresample-6.dll" "$<TARGET_FILE_DIR:VideoEditor>"
-        COMMENT "Copying FFmpeg DLLs"
+        COMMENT "Copiando DLLs de FFmpeg dinámico..."
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,16 @@ find_library(CURL_LIBRARY
     NO_DEFAULT_PATH
 )
 
+if(NOT USE_STATIC_FFMPEG)
+    # Vendored libcurl requires zlib when linking dynamically
+    set(CURL_ZLIB_LIBRARY "${CURL_ROOT}/lib/zlib.lib" CACHE FILEPATH "Path to zlib for vendored curl")
+    if(EXISTS "${CURL_ZLIB_LIBRARY}")
+        message(STATUS "Found curl zlib: ${CURL_ZLIB_LIBRARY}")
+    else()
+        message(FATAL_ERROR "curl zlib library not found: ${CURL_ZLIB_LIBRARY}")
+    endif()
+endif()
+
 # Create the executable
 add_executable(VideoEditor WIN32
     src/main.cpp src/window_proc.cpp src/ui_controls.cpp src/file_handling.cpp src/ui_updates.cpp src/timeline.cpp src/editing.cpp src/utils.cpp src/video_decoder.cpp src/audio_player.cpp src/video_renderer.cpp src/video_cutter.cpp
@@ -145,6 +155,10 @@ target_link_libraries(VideoEditor PRIVATE
     ${SWRESAMPLE_LIBRARY}
     ${FFMPEG_EXTRA_LIBS}
 )
+
+if(NOT USE_STATIC_FFMPEG)
+    target_link_libraries(VideoEditor PRIVATE ${CURL_ZLIB_LIBRARY})
+endif()
 
 # Copy FFmpeg DLLs when linking dynamically
 if(WIN32 AND NOT USE_STATIC_FFMPEG)

--- a/run.ps1
+++ b/run.ps1
@@ -175,12 +175,13 @@ Write-Host "Usando vcpkg toolchain: $env:CMAKE_TOOLCHAIN_FILE" -ForegroundColor 
 
 # 5) Configurar/reconfigurar CMake
 $staticFlag = if ($Static.IsPresent) { "ON" } else { "OFF" }
+Write-Host "Argumentos de CMake: -DUSE_STATIC_FFMPEG=$staticFlag, -DFFMPEG_ROOT=$FFmpegPath, -DCURL_ROOT=$env:CURL_ROOT" -ForegroundColor Cyan
 if (-not (Test-Path ".\build")) {
     Write-Host "Configurando CMake..." -ForegroundColor Yellow
-    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag "-DFFMPEG_ROOT=$FFmpegPath" "-DCURL_ROOT=$env:CURL_ROOT"
+    cmake -S . -B build -D "USE_STATIC_FFMPEG:BOOL=$staticFlag" "-DFFMPEG_ROOT=$FFmpegPath" "-DCURL_ROOT=$env:CURL_ROOT"
 } else {
     Write-Host "Reconfigurando CMake con nuevos parámetros..." -ForegroundColor Yellow
-    cmake -S . -B build -DUSE_STATIC_FFMPEG=$staticFlag "-DFFMPEG_ROOT=$FFmpegPath" "-DCURL_ROOT=$env:CURL_ROOT"
+    cmake -S . -B build -D "USE_STATIC_FFMPEG:BOOL=$staticFlag" "-DFFMPEG_ROOT=$FFmpegPath" "-DCURL_ROOT=$env:CURL_ROOT"
 }
 if ($LASTEXITCODE -ne 0) { Write-Error "Fallo la configuración de CMake."; exit 1 }
 

--- a/run.ps1
+++ b/run.ps1
@@ -156,6 +156,9 @@ if ($Static.IsPresent) {
         "$curlRoot\include\curl\curl.h",
         "$curlRoot\lib\libcurl.lib"
     )
+    if ($curlRoot -eq $VendoredCurl) {
+        $required += "$curlRoot\lib\zlib.lib"
+    }
 }
 
 foreach ($p in $required) {


### PR DESCRIPTION
## Summary
- require zlib from vendored curl when using dynamic FFmpeg
- link zlib automatically in dynamic builds
- only check for zlib in script when vendored curl is used

## Testing
- `cmake -S . -B build -DUSE_STATIC_FFMPEG=OFF` *(fails: curl zlib library not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871511a11b0832f8201a0b55acf4275