### PR TITLE
Use third_party path for ffmpeg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,14 @@ jobs:
                 name: Install FFmpeg (dynamic)
                 shell: powershell
                 command: |
-                  New-Item -ItemType Directory -Force -Path "C:/Program Files/ffmpeg"
+                  New-Item -ItemType Directory -Force -Path "./third_party/ffmpeg"
                   $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip"
                   $zipPath = "C:/ffmpeg.zip"
                   Invoke-WebRequest -Uri $url -OutFile $zipPath
                   $tempExtractDir = "C:/ffmpeg_temp"
                   Expand-Archive -Path $zipPath -DestinationPath $tempExtractDir
                   $unzipped = Get-ChildItem -Path $tempExtractDir | Select-Object -First 1
-                  Move-Item -Path (Join-Path $unzipped.FullName "*") -Destination "C:/Program Files/ffmpeg"
+                  Move-Item -Path (Join-Path $unzipped.FullName "*") -Destination "./third_party/ffmpeg"
                   Remove-Item $zipPath
                   Remove-Item $tempExtractDir -Recurse
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_definitions(UNICODE _UNICODE)
 
 # Default paths (can override with -DFFMPEG_ROOT=... or -DCURL_ROOT=...)
-set(FFMPEG_ROOT "C:/Program Files/ffmpeg" CACHE PATH "Path to FFmpeg installation")
+set(FFMPEG_ROOT "${CMAKE_SOURCE_DIR}/third_party/ffmpeg" CACHE PATH "Path to FFmpeg installation")
 set(CURL_ROOT   "${CMAKE_SOURCE_DIR}/vendor/libcurl" CACHE PATH "Path to libcurl installation")
 
 # ==== FIND FFmpeg ====

--- a/run.ps1
+++ b/run.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$FFmpegPath = "C:\Program Files\ffmpeg",
+    [string]$FFmpegPath = "$PSScriptRoot\third_party\ffmpeg",
     [switch]$Static
 )
 
@@ -43,7 +43,7 @@ $VendoredCurl = Join-Path $PSScriptRoot 'vendor\libcurl'
 # vcpkg install ffmpeg[dav1d,openh264,x264,x265,mp3lame,fdk-aac,opus,zlib,ffmpeg]:x64-windows-static
 # If static build is requested and the default path wasn't changed,
 # try to guess the static vcpkg location.
-if ($Static -and $FFmpegPath -eq "C:\Program Files\ffmpeg") {
+if ($Static -and $FFmpegPath -eq "$PSScriptRoot\third_party\ffmpeg") {
     $guess = "C:\tools\vcpkg\installed\x64-windows-static"
     if (Test-Path "$guess\lib\avcodec.lib") {
         Write-Host "Static mode detected. Using FFmpeg from $guess" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- switch default FFmpeg path to `./third_party/ffmpeg`
- update build script and CI to use the new location
- adjust CMakeLists default FFmpeg root

## Testing
- `cmake -S . -B build -DUSE_STATIC_FFMPEG=OFF -DFFMPEG_ROOT="./third_party/ffmpeg" -DCURL_ROOT="vendor/libcurl"` *(fails: FFMPEG_INCLUDE_DIR-NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6877e6a9e34c832fb1299068ceee9e5a