### PR TITLE
Add custom B2 URL and upload progress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ add_executable(VideoEditor WIN32
     src/options_window.cpp
     src/progress_window.cpp
     src/b2_upload.cpp
+    src/upload_dialog.cpp
 )
 
 # ==== INCLUDE DIRECTORIES ====

--- a/src/b2_upload.cpp
+++ b/src/b2_upload.cpp
@@ -2,11 +2,22 @@
 #include "options_window.h"
 #include <curl/curl.h>
 #include <string>
+#include <commctrl.h>
 
 static size_t WriteCB(char* ptr, size_t size, size_t nmemb, void* userdata) {
     std::string* out = static_cast<std::string*>(userdata);
     out->append(ptr, size * nmemb);
     return size * nmemb;
+}
+
+static int ProgressCB(void* clientp, curl_off_t dltotal, curl_off_t dlnow,
+                      curl_off_t ultotal, curl_off_t ulnow) {
+    HWND bar = reinterpret_cast<HWND>(clientp);
+    if (bar && ultotal > 0) {
+        int pct = static_cast<int>((double)ulnow / ultotal * 100.0);
+        SendMessage(bar, PBM_SETPOS, pct, 0);
+    }
+    return 0;
 }
 
 static std::string Narrow(const std::wstring& w) {
@@ -29,7 +40,7 @@ static bool ExtractJson(const std::string& json, const std::string& key, std::st
     return true;
 }
 
-bool UploadToB2(const std::wstring& filePath, std::string& outUrl) {
+bool UploadToB2(const std::wstring& filePath, std::string& outUrl, HWND progressBar) {
     if (g_b2KeyId.empty() || g_b2AppKey.empty() || g_b2BucketId.empty() || g_b2BucketName.empty())
         return false;
 
@@ -97,6 +108,12 @@ bool UploadToB2(const std::wstring& filePath, std::string& outUrl) {
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
     curl_easy_setopt(curl, CURLOPT_READDATA, fp);
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsz);
+    if (progressBar) {
+        SendMessage(progressBar, PBM_SETPOS, 0, 0);
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, ProgressCB);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, progressBar);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    }
     response.clear();
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCB);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
@@ -106,7 +123,13 @@ bool UploadToB2(const std::wstring& filePath, std::string& outUrl) {
     fclose(fp);
     if (res != CURLE_OK) { curl_easy_cleanup(curl); return false; }
 
-    outUrl = downloadUrl + "/file/" + Narrow(g_b2BucketName) + "/" + name;
+    if (!g_b2CustomUrl.empty()) {
+        std::string base = Narrow(g_b2CustomUrl);
+        if (base.back() != '/' && base.back() != '\\') base += '/';
+        outUrl = base + name;
+    } else {
+        outUrl = downloadUrl + "/file/" + Narrow(g_b2BucketName) + "/" + name;
+    }
     curl_easy_cleanup(curl);
     return true;
 }

--- a/src/b2_upload.h
+++ b/src/b2_upload.h
@@ -2,4 +2,4 @@
 #include <string>
 #include <windows.h>
 
-bool UploadToB2(const std::wstring& filePath, std::string& outUrl);
+bool UploadToB2(const std::wstring& filePath, std::string& outUrl, HWND progressBar = nullptr);

--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -115,6 +115,7 @@ void OnCutClicked(HWND hwnd)
                                              mergeAudio, convertH264, g_useNvenc,
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload) {
+                SetWindowTextW(g_hProgressWindow, L"Uploading video to cloud...");
                 std::string url;
                 if (UploadToB2(outFile, url, g_hProgressBar)) {
                     int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
@@ -193,6 +194,7 @@ void OnExportClicked(HWND hwnd)
                                              mergeAudio, convertH264, g_useNvenc,
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload) {
+                SetWindowTextW(g_hProgressWindow, L"Uploading video to cloud...");
                 std::string url;
                 if (UploadToB2(outFile, url, g_hProgressBar)) {
                     int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);

--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -116,7 +116,7 @@ void OnCutClicked(HWND hwnd)
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload) {
                 std::string url;
-                if (UploadToB2(outFile, url)) {
+                if (UploadToB2(outFile, url, g_hProgressBar)) {
                     int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
                     g_uploadedUrl.assign(sz - 1, 0);
                     MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_uploadedUrl.data(), sz);
@@ -194,7 +194,7 @@ void OnExportClicked(HWND hwnd)
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload) {
                 std::string url;
-                if (UploadToB2(outFile, url)) {
+                if (UploadToB2(outFile, url, g_hProgressBar)) {
                     int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
                     g_uploadedUrl.assign(sz - 1, 0);
                     MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_uploadedUrl.data(), sz);

--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -115,7 +115,7 @@ void OnCutClicked(HWND hwnd)
                                              mergeAudio, convertH264, g_useNvenc,
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload) {
-                SetWindowTextW(g_hProgressWindow, L"Uploading video to cloud...");
+                SetWindowTextW(g_hProgressWindow, L"Uploading to cloud");
                 std::string url;
                 if (UploadToB2(outFile, url, g_hProgressBar)) {
                     int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
@@ -194,7 +194,7 @@ void OnExportClicked(HWND hwnd)
                                              mergeAudio, convertH264, g_useNvenc,
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload) {
-                SetWindowTextW(g_hProgressWindow, L"Uploading video to cloud...");
+                SetWindowTextW(g_hProgressWindow, L"Uploading to cloud");
                 std::string url;
                 if (UploadToB2(outFile, url, g_hProgressBar)) {
                     int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "video_player.h"
 #include "options_window.h"
 #include "progress_window.h"
+#include "upload_dialog.h"
 #include "window_proc.h"
 #include "timeline.h"
 #include "utils.h"
@@ -101,6 +102,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
     pwc.hCursor = LoadCursor(nullptr, IDC_ARROW);
     pwc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
     RegisterClass(&pwc);
+
+    WNDCLASS ucw = {};
+    ucw.lpfnWndProc = UrlCopyProc;
+    ucw.hInstance = hInstance;
+    ucw.lpszClassName = L"UrlCopyClass";
+    ucw.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    ucw.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    RegisterClass(&ucw);
 
     HWND hwnd = CreateWindowEx(
         0, CLASS_NAME, L"Video Editor - Preview",

--- a/src/options_window.h
+++ b/src/options_window.h
@@ -16,6 +16,7 @@
 #define ID_EDIT_B2_BUCKET_ID    2003
 #define ID_EDIT_B2_BUCKET_NAME  2004
 #define ID_CHECKBOX_AUTO_UPLOAD 2005
+#define ID_EDIT_B2_CUSTOM_URL   2006
 
 extern bool g_useNvenc;
 extern bool g_logToFile;
@@ -24,6 +25,7 @@ extern std::wstring g_b2KeyId;
 extern std::wstring g_b2AppKey;
 extern std::wstring g_b2BucketId;
 extern std::wstring g_b2BucketName;
+extern std::wstring g_b2CustomUrl;
 extern bool g_autoUpload;
 
 void ShowB2ConfigWindow(HWND parent);

--- a/src/progress_window.cpp
+++ b/src/progress_window.cpp
@@ -10,13 +10,14 @@ void ApplyDarkTheme(HWND hwnd);
 
 void ShowProgressWindow(HWND parent) {
     if (g_hProgressWindow) {
+        SetWindowTextW(g_hProgressWindow, L"Exporting video");
         ShowWindow(g_hProgressWindow, SW_SHOW);
         UpdateWindow(g_hProgressWindow);
         return;
     }
 
     g_hProgressWindow = CreateWindowEx(
-        WS_EX_TOPMOST, L"ProgressClass", L"Exporting...",
+        WS_EX_TOPMOST, L"ProgressClass", L"Exporting video",
         WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU,
         CW_USEDEFAULT, CW_USEDEFAULT, 300, 150,
         parent, nullptr, GetModuleHandle(nullptr), nullptr);

--- a/src/progress_window.h
+++ b/src/progress_window.h
@@ -8,6 +8,7 @@
 
 extern std::atomic<bool> g_cancelExport;
 extern HWND g_hProgressBar;
+extern HWND g_hProgressWindow;
 
 void ShowProgressWindow(HWND parent);
 void CloseProgressWindow();

--- a/src/upload_dialog.cpp
+++ b/src/upload_dialog.cpp
@@ -1,0 +1,63 @@
+#include "upload_dialog.h"
+#include "utils.h"
+
+static HWND g_hUrlDlg = nullptr;
+static std::wstring g_url;
+
+void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstring& url) {
+    g_url = url;
+    if (g_hUrlDlg) DestroyWindow(g_hUrlDlg);
+    g_hUrlDlg = CreateWindowEx(0, L"UrlCopyClass", L"Upload Complete",
+                               WS_CAPTION | WS_POPUPWINDOW | WS_VISIBLE,
+                               CW_USEDEFAULT, CW_USEDEFAULT, 360, 160,
+                               parent, nullptr,
+                               (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
+    if (!g_hUrlDlg) return;
+    ApplyDarkTheme(g_hUrlDlg);
+    CreateWindow(L"STATIC", message.c_str(), WS_CHILD | WS_VISIBLE | SS_LEFT,
+                 10, 10, 330, 40, g_hUrlDlg, nullptr,
+                 (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+    HWND hEdit = CreateWindow(L"EDIT", url.c_str(),
+                              WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | ES_READONLY,
+                              10, 55, 330, 20, g_hUrlDlg, (HMENU)1,
+                              (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+    HWND hCopy = CreateWindow(L"BUTTON", L"Copy", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+                              70, 100, 80, 25, g_hUrlDlg, (HMENU)2,
+                              (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+    HWND hOk = CreateWindow(L"BUTTON", L"OK", WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
+                            190, 100, 80, 25, g_hUrlDlg, (HMENU)3,
+                            (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(hEdit);
+    ApplyDarkTheme(hCopy);
+    ApplyDarkTheme(hOk);
+}
+
+LRESULT CALLBACK UrlCopyProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+    case WM_COMMAND:
+        if (LOWORD(wParam) == 2) {
+            if (OpenClipboard(hwnd)) {
+                EmptyClipboard();
+                size_t sz = (g_url.size() + 1) * sizeof(wchar_t);
+                HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, sz);
+                if (hMem) {
+                    memcpy(GlobalLock(hMem), g_url.c_str(), sz);
+                    GlobalUnlock(hMem);
+                    SetClipboardData(CF_UNICODETEXT, hMem);
+                }
+                CloseClipboard();
+            }
+        } else if (LOWORD(wParam) == 3) {
+            DestroyWindow(hwnd);
+        }
+        break;
+    case WM_CLOSE:
+        DestroyWindow(hwnd);
+        break;
+    case WM_DESTROY:
+        g_hUrlDlg = nullptr;
+        break;
+    }
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+

--- a/src/upload_dialog.h
+++ b/src/upload_dialog.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <windows.h>
+#include <string>
+
+void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstring& url);
+LRESULT CALLBACK UrlCopyProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
## Summary
- support custom Backblaze download URL and save in settings
- show progress bar when uploading to B2
- provide dialog with copyable link when upload succeeds

## Testing
- `cmake -B build` *(fails: FFMPEG libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc00925d8832fb0032f63ca627402