### PR TITLE
Fix playback looping fast after video end

### DIFF
--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -228,6 +228,7 @@ void VideoPlayer::Stop()
 {
     Pause();
     currentFrame = 0;
+    currentPts = 0.0;
     if (isLoaded)
     {
         av_seek_frame(formatContext, videoStreamIndex, 0, AVSEEK_FLAG_FRAME);


### PR DESCRIPTION
## Summary
- reset current playback timestamp when stopping

## Testing
- `cmake ..` (fails: FFMPEG include not found)

------
https://chatgpt.com/codex/tasks/task_e_687fcf4fb314832f99089df373d43dc9