### PR TITLE
Allow open with support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ using `-FFmpegPath`.
 1. Click "Open Video" to select a video file
 2. The application will automatically detect and list all audio tracks
 3. Audio tracks appear in the "Audio Tracks" list on the right side
+4. You can also pass a video file path as a command line argument or use
+   Windows "Open with..." to launch the program with that video already loaded
 
 ### Controlling Audio Tracks
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "window_proc.h"
 #include "timeline.h"
 #include "utils.h"
+#include "file_handling.h"
 
 #include <string>
 #include <cstdlib>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow)
     ShowWindow(hwnd, nCmdShow);
     UpdateWindow(hwnd);
 
+    int argc;
+    LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (argv && argc > 1)
+    {
+        LoadVideoFile(hwnd, std::wstring(argv[1]));
+    }
+    if (argv)
+        LocalFree(argv);
+
     MSG msg = {};
     while (GetMessage(&msg, nullptr, 0, 0) > 0)
     {


### PR DESCRIPTION
## Summary
- open a video automatically if a file path is provided on the command line
- document that you can launch the app via Windows "Open with" or by passing a file path

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_688c001bb604832f80afe910ee399f92