### PR TITLE
Fix timeline cursor lag on slower PCs

### DIFF
--- a/src/video_decoder.cpp
+++ b/src/video_decoder.cpp
@@ -2,6 +2,7 @@
 #include "video_player.h"
 #include "audio_player.h"
 #include "video_renderer.h"
+#include "ui_updates.h"
 
 VideoDecoder::VideoDecoder(VideoPlayer* player) : m_player(player) {}
 
@@ -191,6 +192,8 @@ bool VideoDecoder::DecodeNextFrame(bool updateDisplay) {
                 {
                     InvalidateRect(m_player->videoWindow, nullptr, FALSE);
                 }
+
+                UpdateTimeline();
 
                 return true;
             }


### PR DESCRIPTION
## Summary
- Invalidate the timeline after decoding each frame to keep the cursor moving during playback.

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR, AVCODEC_LIBRARY, AVFORMAT_LIBRARY, AVUTIL_LIBRARY, SWRESAMPLE_LIBRARY, SWSCALE_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a35b34b1d0832f85fb17cdd1b930c8