### PR TITLE
Center sub-windows on parent

### DIFF
--- a/src/options_window.cpp
+++ b/src/options_window.cpp
@@ -1,7 +1,5 @@
 #include "options_window.h"
-
-// Forward declaration from main.cpp for styling
-void ApplyDarkTheme(HWND hwnd);
+#include "utils.h"
 
 static HWND g_hOptionsWnd = nullptr;
 static HWND g_hUploadWnd = nullptr;
@@ -108,6 +106,7 @@ void ShowOptionsWindow(HWND parent)
                                    parent, nullptr,
                                    (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(g_hOptionsWnd);
+    CenterWindow(g_hOptionsWnd, parent);
 
     CreateWindow(L"STATIC", L"Encode H264:", WS_CHILD | WS_VISIBLE,
                  10, 10, 120, 20, g_hOptionsWnd, nullptr,
@@ -211,6 +210,7 @@ void ShowB2ConfigWindow(HWND parent)
                               parent, nullptr,
                               (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(g_hB2Wnd);
+    CenterWindow(g_hB2Wnd, parent);
 
     CreateWindow(L"STATIC", L"Key ID:", WS_CHILD | WS_VISIBLE,
                  10, 10, 100, 20, g_hB2Wnd, nullptr,
@@ -342,6 +342,7 @@ void ShowUploadWindow(HWND parent)
                                   parent, nullptr,
                                   (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(g_hUploadWnd);
+    CenterWindow(g_hUploadWnd, parent);
 
     HWND hAuto = CreateWindow(L"BUTTON", L"Auto upload after export",
                               WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX,
@@ -424,6 +425,7 @@ void ShowCatboxConfigWindow(HWND parent)
                                   parent, nullptr,
                                   (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(g_hCatboxWnd);
+    CenterWindow(g_hCatboxWnd, parent);
 
     CreateWindow(L"STATIC", L"User Hash:", WS_CHILD | WS_VISIBLE,
                  10, 10, 100, 20, g_hCatboxWnd, nullptr,

--- a/src/progress_window.cpp
+++ b/src/progress_window.cpp
@@ -1,12 +1,10 @@
 #include "progress_window.h"
 #include <commctrl.h>
+#include "utils.h"
 
 std::atomic<bool> g_cancelExport(false);
 HWND g_hProgressBar = nullptr;
 HWND g_hProgressWindow = nullptr;
-
-// Forward declaration for the dark theme function if needed
-void ApplyDarkTheme(HWND hwnd);
 
 void ShowProgressWindow(HWND parent) {
     if (g_hProgressWindow) {
@@ -23,14 +21,7 @@ void ShowProgressWindow(HWND parent) {
         parent, nullptr, GetModuleHandle(nullptr), nullptr);
 
     if (g_hProgressWindow) {
-        // Center the window
-        RECT parentRect, windowRect;
-        GetWindowRect(parent, &parentRect);
-        GetWindowRect(g_hProgressWindow, &windowRect);
-        int x = parentRect.left + (parentRect.right - parentRect.left - (windowRect.right - windowRect.left)) / 2;
-        int y = parentRect.top + (parentRect.bottom - parentRect.top - (windowRect.bottom - windowRect.top)) / 2;
-        SetWindowPos(g_hProgressWindow, HWND_TOPMOST, x, y, 0, 0, SWP_NOSIZE);
-
+        CenterWindow(g_hProgressWindow, parent);
         ShowWindow(g_hProgressWindow, SW_SHOW);
         UpdateWindow(g_hProgressWindow);
     }

--- a/src/upload_dialog.cpp
+++ b/src/upload_dialog.cpp
@@ -14,6 +14,7 @@ void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstr
                                (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
     if (!g_hUrlDlg) return;
     ApplyDarkTheme(g_hUrlDlg);
+    CenterWindow(g_hUrlDlg, parent);
     CreateWindow(L"STATIC", message.c_str(), WS_CHILD | WS_VISIBLE | SS_LEFT,
                  10, 10, 330, 40, g_hUrlDlg, nullptr,
                  (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -46,3 +46,21 @@ void ApplyDarkTheme(HWND hwnd)
         SendMessage(hwnd, WM_SETFONT, (WPARAM)g_hFont, TRUE);
     SetWindowTheme(hwnd, L"DarkMode_Explorer", nullptr);
 }
+
+void CenterWindow(HWND hwnd, HWND parent)
+{
+    RECT rcWnd, rcParent;
+    GetWindowRect(hwnd, &rcWnd);
+    if (parent)
+        GetWindowRect(parent, &rcParent);
+    else {
+        rcParent.left = 0;
+        rcParent.top = 0;
+        rcParent.right = GetSystemMetrics(SM_CXSCREEN);
+        rcParent.bottom = GetSystemMetrics(SM_CYSCREEN);
+    }
+
+    int x = rcParent.left + (rcParent.right - rcParent.left - (rcWnd.right - rcWnd.left)) / 2;
+    int y = rcParent.top + (rcParent.bottom - rcParent.top - (rcWnd.bottom - rcWnd.top)) / 2;
+    SetWindowPos(hwnd, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,3 +6,4 @@
 std::wstring FormatTime(double totalSeconds, bool showMilliseconds = false);
 double ParseTimeString(const std::wstring& str);
 void ApplyDarkTheme(HWND hwnd);
+void CenterWindow(HWND hwnd, HWND parent);


### PR DESCRIPTION
## Summary
- add `CenterWindow` helper to position windows relative to their parent
- center options, upload, progress and URL dialogs using the new helper

## Testing
- `cmake ..` *(fails: FFMPEG_INCLUDE_DIR not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6010804d0832fac9a423d250288dd