### PR TITLE
Add interactive crop feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All source files now reside under the `src/` directory to keep the project organ
 ### Cutting and Exporting Clips
 
 - **Set Start/End Points**: Mark the portion of the video to export
+- **Interactive Crop**: Drag on the video preview to select a cropped region for export
 - **Merge Audio Tracks**: Combine all unmuted tracks into one output stream
 - **Codec Options**: Copy video/audio codecs for a fast cut or convert to H.264
 - **Bitrate or Target Size**: When converting to H.264 you can either set a bitrate or specify a desired final size; only the chosen option is shown

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <sstream>
 #include <commctrl.h>
+#include <libavutil/frame.h>
 
 VideoCutter::VideoCutter(VideoPlayer* player) : m_player(player) {}
 
@@ -55,6 +56,8 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
     // When re-encoding or merging audio we need to set up decoder/encoder
     // contexts. The previous implementation only supported stream copying.
     // Build encoder state on demand.
+    if (m_player->hasCrop)
+        convertH264 = true;
     bool success = true;
     AVCodecContext* vEncCtx = nullptr;
     AVCodecContext* vDecCtx = nullptr;
@@ -128,8 +131,12 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
             outStream = avformat_new_stream(outputCtx, vEnc);
             vEncCtx = avcodec_alloc_context3(vEnc);
             vEncCtx->codec_id = AV_CODEC_ID_H264;
-            vEncCtx->width = inStream->codecpar->width;
-            vEncCtx->height = inStream->codecpar->height;
+            int outW = m_player->hasCrop ? (m_player->cropRect.right - m_player->cropRect.left)
+                                         : inStream->codecpar->width;
+            int outH = m_player->hasCrop ? (m_player->cropRect.bottom - m_player->cropRect.top)
+                                         : inStream->codecpar->height;
+            vEncCtx->width = outW;
+            vEncCtx->height = outH;
             vEncCtx->time_base = inStream->time_base;
             vEncCtx->pix_fmt = AV_PIX_FMT_YUV420P;
             vEncCtx->max_b_frames = 2;
@@ -329,8 +336,15 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
         if (convertH264 && pkt.stream_index == m_player->videoStreamIndex) {
             avcodec_send_packet(vDecCtx, &pkt);
             while (avcodec_receive_frame(vDecCtx, decFrame) == 0) {
+                if (m_player->hasCrop) {
+                    decFrame->crop_left = m_player->cropRect.left;
+                    decFrame->crop_top = m_player->cropRect.top;
+                    decFrame->crop_right = vDecCtx->width - m_player->cropRect.right;
+                    decFrame->crop_bottom = vDecCtx->height - m_player->cropRect.bottom;
+                    av_frame_apply_cropping(decFrame, 0);
+                }
                 if (!swsCtx) {
-                    swsCtx = sws_getContext(vDecCtx->width, vDecCtx->height,
+                    swsCtx = sws_getContext(decFrame->width, decFrame->height,
                                             (AVPixelFormat)decFrame->format,
                                             vEncCtx->width, vEncCtx->height,
                                             vEncCtx->pix_fmt, SWS_BILINEAR,
@@ -342,7 +356,7 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                         goto cleanup;
                     }
                 }
-                sws_scale(swsCtx, decFrame->data, decFrame->linesize, 0, vDecCtx->height, encFrame->data, encFrame->linesize);
+                sws_scale(swsCtx, decFrame->data, decFrame->linesize, 0, decFrame->height, encFrame->data, encFrame->linesize);
                 encFrame->pts = av_rescale_q(decFrame->pts - av_rescale_q(startPts, AV_TIME_BASE_Q, inStream->time_base), inStream->time_base, vEncCtx->time_base);
                 avcodec_send_frame(vEncCtx, encFrame);
                 while (avcodec_receive_packet(vEncCtx, &outPkt) == 0) {

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -19,7 +19,9 @@ VideoPlayer::VideoPlayer(HWND parent)
       hwPixelFormat(AV_PIX_FMT_NONE), useHwAccel(false), packet(nullptr), swsContext(nullptr),
       buffer(nullptr), videoStreamIndex(-1), frameWidth(0), frameHeight(0),
       isLoaded(false), isPlaying(false), frameRate(0), currentFrame(0),
-      totalFrames(0), currentPts(0.0), duration(0.0), startTimeOffset(0.0), videoWindow(nullptr),
+      totalFrames(0), currentPts(0.0), duration(0.0), startTimeOffset(0.0),
+      cropRect{0,0,0,0}, hasCrop(false), selectingCrop(false), cropStart{0,0}, cropCurrent{0,0},
+      videoWindow(nullptr),
       d2dFactory(nullptr), d2dRenderTarget(nullptr), d2dBitmap(nullptr), playbackTimer(0),
       deviceEnumerator(nullptr), audioDevice(nullptr), audioClient(nullptr),
       renderClient(nullptr), audioFormat(nullptr), bufferFrameCount(0),
@@ -413,6 +415,68 @@ LRESULT CALLBACK VideoPlayer::VideoWindowProc(HWND hwnd, UINT msg, WPARAM wParam
         else if (msg == WM_ERASEBKGND)
         {
             return 1;
+        }
+        else if (msg == WM_LBUTTONDOWN && player->isLoaded)
+        {
+            player->selectingCrop = true;
+            player->cropStart = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            player->cropCurrent = player->cropStart;
+            SetCapture(hwnd);
+            return 0;
+        }
+        else if (msg == WM_MOUSEMOVE && player->selectingCrop)
+        {
+            player->cropCurrent = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return 0;
+        }
+        else if (msg == WM_LBUTTONUP && player->selectingCrop)
+        {
+            player->selectingCrop = false;
+            ReleaseCapture();
+            player->cropCurrent = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            RECT winRect = { std::min(player->cropStart.x, player->cropCurrent.x),
+                             std::min(player->cropStart.y, player->cropCurrent.y),
+                             std::max(player->cropStart.x, player->cropCurrent.x),
+                             std::max(player->cropStart.y, player->cropCurrent.y) };
+            RECT client; GetClientRect(hwnd, &client);
+            float wndW = (float)(client.right - client.left);
+            float wndH = (float)(client.bottom - client.top);
+            float videoAspect = static_cast<float>(player->frameWidth) / player->frameHeight;
+            float targetAspect = wndW / wndH;
+            float drawW, drawH, offsetX, offsetY;
+            if (targetAspect > videoAspect) {
+                drawH = wndH;
+                drawW = drawH * videoAspect;
+                offsetX = (wndW - drawW) / 2.0f;
+                offsetY = 0.0f;
+            } else {
+                drawW = wndW;
+                drawH = drawW / videoAspect;
+                offsetX = 0.0f;
+                offsetY = (wndH - drawH) / 2.0f;
+            }
+            float x1 = std::clamp((float)winRect.left - offsetX, 0.0f, drawW);
+            float y1 = std::clamp((float)winRect.top - offsetY, 0.0f, drawH);
+            float x2 = std::clamp((float)winRect.right - offsetX, 0.0f, drawW);
+            float y2 = std::clamp((float)winRect.bottom - offsetY, 0.0f, drawH);
+            if (x2 > x1 && y2 > y1) {
+                player->cropRect.left = (LONG)(x1 / drawW * player->frameWidth);
+                player->cropRect.top = (LONG)(y1 / drawH * player->frameHeight);
+                player->cropRect.right = (LONG)(x2 / drawW * player->frameWidth);
+                player->cropRect.bottom = (LONG)(y2 / drawH * player->frameHeight);
+                player->hasCrop = true;
+            } else {
+                player->hasCrop = false;
+            }
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return 0;
+        }
+        else if (msg == WM_RBUTTONUP && player->hasCrop)
+        {
+            player->hasCrop = false;
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return 0;
         }
         return CallWindowProc(player->originalVideoWndProc, hwnd, msg, wParam, lParam);
     }

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -89,6 +89,13 @@ public:
     double duration;
     double startTimeOffset;
 
+    // Crop selection
+    RECT cropRect;
+    bool hasCrop;
+    bool selectingCrop;
+    POINT cropStart;
+    POINT cropCurrent;
+
     HWND parentWindow;
     HWND videoWindow;
     WNDPROC originalVideoWndProc;

--- a/src/video_renderer.cpp
+++ b/src/video_renderer.cpp
@@ -1,6 +1,7 @@
 #include "video_renderer.h"
 #include "video_player.h"
 #include "video_decoder.h"
+#include <algorithm>
 
 VideoRenderer::VideoRenderer(VideoPlayer* player) : m_player(player) {}
 
@@ -56,8 +57,17 @@ void VideoRenderer::UpdateDisplay() {
     m_player->d2dRenderTarget->BeginDraw();
     m_player->d2dRenderTarget->Clear(D2D1::ColorF(D2D1::ColorF::Black));
     D2D1_SIZE_F size = m_player->d2dRenderTarget->GetSize();
+    int srcW = m_player->frameWidth;
+    int srcH = m_player->frameHeight;
+    D2D1_RECT_F srcRect = {};
+    if (m_player->hasCrop) {
+        srcW = m_player->cropRect.right - m_player->cropRect.left;
+        srcH = m_player->cropRect.bottom - m_player->cropRect.top;
+        srcRect = D2D1::RectF((FLOAT)m_player->cropRect.left, (FLOAT)m_player->cropRect.top,
+                              (FLOAT)m_player->cropRect.right, (FLOAT)m_player->cropRect.bottom);
+    }
     float targetAspect = size.width / size.height;
-    float videoAspect = static_cast<float>(m_player->frameWidth) / m_player->frameHeight;
+    float videoAspect = static_cast<float>(srcW) / srcH;
     float drawWidth = size.width;
     float drawHeight = size.height;
     float offsetX = 0.0f;
@@ -79,7 +89,20 @@ void VideoRenderer::UpdateDisplay() {
         m_player->d2dBitmap,
         D2D1::RectF(offsetX, offsetY, offsetX + drawWidth, offsetY + drawHeight),
         1.0f,
-        D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);
+        D2D1_BITMAP_INTERPOLATION_MODE_LINEAR,
+        m_player->hasCrop ? &srcRect : nullptr);
+
+    if (m_player->selectingCrop) {
+        D2D1_RECT_F sel = D2D1::RectF(
+            (FLOAT)std::min(m_player->cropStart.x, m_player->cropCurrent.x),
+            (FLOAT)std::min(m_player->cropStart.y, m_player->cropCurrent.y),
+            (FLOAT)std::max(m_player->cropStart.x, m_player->cropCurrent.x),
+            (FLOAT)std::max(m_player->cropStart.y, m_player->cropCurrent.y));
+        ID2D1SolidColorBrush* brush = nullptr;
+        m_player->d2dRenderTarget->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Yellow), &brush);
+        m_player->d2dRenderTarget->DrawRectangle(sel, brush, 2.0f);
+        if (brush) brush->Release();
+    }
     m_player->d2dRenderTarget->EndDraw();
 }
 


### PR DESCRIPTION
## Summary
- allow selecting a crop rectangle directly on the video preview
- render and export using the chosen crop area
- document interactive cropping in README

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74ac647e8832f9c9c5167078934b2