### PR TITLE
Handle dual uploads and remove catbox popup

### DIFF
--- a/src/catbox_upload.cpp
+++ b/src/catbox_upload.cpp
@@ -119,6 +119,9 @@ bool UploadToCatbox(const std::wstring& filePath, std::string& outUrl, HWND prog
     DebugLog("Catbox response: " + outUrl);
     curl_easy_cleanup(curl);
     bool ok = !outUrl.empty() && outUrl.rfind("http", 0) == 0;
-    DebugLog(ok ? "Catbox upload succeeded" : "Catbox returned invalid URL", true);
+    if (ok)
+        DebugLog("Catbox upload succeeded");
+    else
+        DebugLog("Catbox returned invalid URL", true);
     return ok;
 }

--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -20,7 +20,10 @@ extern bool g_useNvenc;
 extern bool g_autoUpload;
 extern bool g_useCatbox;
 extern bool g_useB2;
-std::wstring g_uploadedUrl;
+std::wstring g_catboxUploadedUrl;
+std::wstring g_b2UploadedUrl;
+bool g_catboxUploadSuccess = false;
+bool g_b2UploadSuccess = false;
 bool g_uploadSuccess = false;
 bool g_lastOperationWasExport = false;
 
@@ -113,26 +116,41 @@ void OnCutClicked(HWND hwnd)
         std::wstring outFile = szFile;
         std::thread([hwnd, outFile, mergeAudio, convertH264, bitrate, startTime, endTime]() {
             g_uploadSuccess = false;
-            g_uploadedUrl.clear();
+            g_catboxUploadSuccess = false;
+            g_b2UploadSuccess = false;
+            g_catboxUploadedUrl.clear();
+            g_b2UploadedUrl.clear();
             bool ok = g_videoPlayer->CutVideo(outFile, startTime, endTime,
                                              mergeAudio, convertH264, g_useNvenc,
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload && (g_useCatbox || g_useB2)) {
                 std::wstring title = L"Uploading to ";
-                title += g_useCatbox ? L"catbox.moe" : L"Backblaze B2";
+                if (g_useCatbox && g_useB2)
+                    title += L"catbox.moe and Backblaze B2";
+                else if (g_useCatbox)
+                    title += L"catbox.moe";
+                else
+                    title += L"Backblaze B2";
                 SetWindowTextW(g_hProgressWindow, title.c_str());
-                std::string url;
-                bool up = false;
-                if (g_useCatbox)
-                    up = UploadToCatbox(outFile, url, g_hProgressBar);
-                else if (g_useB2)
-                    up = UploadToB2(outFile, url, g_hProgressBar);
-                if (up) {
-                    int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
-                    g_uploadedUrl.assign(sz - 1, 0);
-                    MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_uploadedUrl.data(), sz);
-                    g_uploadSuccess = true;
+                if (g_useCatbox) {
+                    std::string url;
+                    if (UploadToCatbox(outFile, url, g_hProgressBar)) {
+                        int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+                        g_catboxUploadedUrl.assign(sz - 1, 0);
+                        MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_catboxUploadedUrl.data(), sz);
+                        g_catboxUploadSuccess = true;
+                    }
                 }
+                if (g_useB2) {
+                    std::string url;
+                    if (UploadToB2(outFile, url, g_hProgressBar)) {
+                        int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+                        g_b2UploadedUrl.assign(sz - 1, 0);
+                        MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_b2UploadedUrl.data(), sz);
+                        g_b2UploadSuccess = true;
+                    }
+                }
+                g_uploadSuccess = (!g_useCatbox || g_catboxUploadSuccess) && (!g_useB2 || g_b2UploadSuccess);
             }
             PostMessage(hwnd, (WM_APP + 1), ok ? 1 : 0, 0); // WM_APP_CUT_DONE
         }).detach();
@@ -199,26 +217,41 @@ void OnExportClicked(HWND hwnd)
         std::wstring outFile = szFile;
         std::thread([hwnd, outFile, mergeAudio, convertH264, bitrate, startTime, endTime]() {
             g_uploadSuccess = false;
-            g_uploadedUrl.clear();
+            g_catboxUploadSuccess = false;
+            g_b2UploadSuccess = false;
+            g_catboxUploadedUrl.clear();
+            g_b2UploadedUrl.clear();
             bool ok = g_videoPlayer->CutVideo(outFile, startTime, endTime,
                                              mergeAudio, convertH264, g_useNvenc,
                                              bitrate, g_hProgressBar, &g_cancelExport);
             if (ok && g_autoUpload && (g_useCatbox || g_useB2)) {
                 std::wstring title = L"Uploading to ";
-                title += g_useCatbox ? L"catbox.moe" : L"Backblaze B2";
+                if (g_useCatbox && g_useB2)
+                    title += L"catbox.moe and Backblaze B2";
+                else if (g_useCatbox)
+                    title += L"catbox.moe";
+                else
+                    title += L"Backblaze B2";
                 SetWindowTextW(g_hProgressWindow, title.c_str());
-                std::string url;
-                bool up = false;
-                if (g_useCatbox)
-                    up = UploadToCatbox(outFile, url, g_hProgressBar);
-                else if (g_useB2)
-                    up = UploadToB2(outFile, url, g_hProgressBar);
-                if (up) {
-                    int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
-                    g_uploadedUrl.assign(sz - 1, 0);
-                    MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_uploadedUrl.data(), sz);
-                    g_uploadSuccess = true;
+                if (g_useCatbox) {
+                    std::string url;
+                    if (UploadToCatbox(outFile, url, g_hProgressBar)) {
+                        int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+                        g_catboxUploadedUrl.assign(sz - 1, 0);
+                        MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_catboxUploadedUrl.data(), sz);
+                        g_catboxUploadSuccess = true;
+                    }
                 }
+                if (g_useB2) {
+                    std::string url;
+                    if (UploadToB2(outFile, url, g_hProgressBar)) {
+                        int sz = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+                        g_b2UploadedUrl.assign(sz - 1, 0);
+                        MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, g_b2UploadedUrl.data(), sz);
+                        g_b2UploadSuccess = true;
+                    }
+                }
+                g_uploadSuccess = (!g_useCatbox || g_catboxUploadSuccess) && (!g_useB2 || g_b2UploadSuccess);
             }
             PostMessage(hwnd, (WM_APP + 1), ok ? 1 : 0, 0);
         }).detach();

--- a/src/editing.h
+++ b/src/editing.h
@@ -10,4 +10,7 @@ void OnExportClicked(HWND hwnd);
 
 extern bool g_lastOperationWasExport;
 extern bool g_uploadSuccess;
-extern std::wstring g_uploadedUrl;
+extern std::wstring g_catboxUploadedUrl;
+extern std::wstring g_b2UploadedUrl;
+extern bool g_catboxUploadSuccess;
+extern bool g_b2UploadSuccess;

--- a/src/upload_dialog.cpp
+++ b/src/upload_dialog.cpp
@@ -2,14 +2,17 @@
 #include "utils.h"
 
 static HWND g_hUrlDlg = nullptr;
-static std::wstring g_url;
+static std::wstring g_url1;
+static std::wstring g_url2;
 
-void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstring& url) {
-    g_url = url;
+void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstring& url1, const std::wstring& url2) {
+    g_url1 = url1;
+    g_url2 = url2;
     if (g_hUrlDlg) DestroyWindow(g_hUrlDlg);
+    int height = url2.empty() ? 160 : 200;
     g_hUrlDlg = CreateWindowEx(0, L"UrlCopyClass", L"Upload Complete",
                                WS_CAPTION | WS_POPUPWINDOW | WS_VISIBLE,
-                               CW_USEDEFAULT, CW_USEDEFAULT, 360, 160,
+                               CW_USEDEFAULT, CW_USEDEFAULT, 360, height,
                                parent, nullptr,
                                (HINSTANCE)GetWindowLongPtr(parent, GWLP_HINSTANCE), nullptr);
     if (!g_hUrlDlg) return;
@@ -18,31 +21,57 @@ void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstr
     CreateWindow(L"STATIC", message.c_str(), WS_CHILD | WS_VISIBLE | SS_LEFT,
                  10, 10, 330, 40, g_hUrlDlg, nullptr,
                  (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
-    HWND hEdit = CreateWindow(L"EDIT", url.c_str(),
-                              WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | ES_READONLY,
-                              10, 55, 330, 20, g_hUrlDlg, (HMENU)1,
-                              (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
-    HWND hCopy = CreateWindow(L"BUTTON", L"Copy", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
-                              70, 100, 80, 25, g_hUrlDlg, (HMENU)2,
-                              (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
-    HWND hOk = CreateWindow(L"BUTTON", L"OK", WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
-                            190, 100, 80, 25, g_hUrlDlg, (HMENU)3,
-                            (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
-    ApplyDarkTheme(hEdit);
-    ApplyDarkTheme(hCopy);
-    ApplyDarkTheme(hOk);
+    if (url2.empty()) {
+        HWND hEdit = CreateWindow(L"EDIT", url1.c_str(),
+                                  WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | ES_READONLY,
+                                  10, 55, 330, 20, g_hUrlDlg, (HMENU)1,
+                                  (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        HWND hCopy = CreateWindow(L"BUTTON", L"Copy", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+                                  70, 100, 80, 25, g_hUrlDlg, (HMENU)2,
+                                  (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        HWND hOk = CreateWindow(L"BUTTON", L"OK", WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
+                                190, 100, 80, 25, g_hUrlDlg, (HMENU)3,
+                                (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        ApplyDarkTheme(hEdit);
+        ApplyDarkTheme(hCopy);
+        ApplyDarkTheme(hOk);
+    } else {
+        HWND hEdit1 = CreateWindow(L"EDIT", url1.c_str(),
+                                   WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | ES_READONLY,
+                                   10, 55, 240, 20, g_hUrlDlg, (HMENU)1,
+                                   (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        HWND hCopy1 = CreateWindow(L"BUTTON", L"Copy Catbox", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+                                   260, 55, 80, 20, g_hUrlDlg, (HMENU)2,
+                                   (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        HWND hEdit2 = CreateWindow(L"EDIT", url2.c_str(),
+                                   WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | ES_READONLY,
+                                   10, 85, 240, 20, g_hUrlDlg, (HMENU)4,
+                                   (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        HWND hCopy2 = CreateWindow(L"BUTTON", L"Copy B2", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+                                   260, 85, 80, 20, g_hUrlDlg, (HMENU)5,
+                                   (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        HWND hOk = CreateWindow(L"BUTTON", L"OK", WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
+                                140, 130, 80, 25, g_hUrlDlg, (HMENU)3,
+                                (HINSTANCE)GetWindowLongPtr(g_hUrlDlg, GWLP_HINSTANCE), nullptr);
+        ApplyDarkTheme(hEdit1);
+        ApplyDarkTheme(hCopy1);
+        ApplyDarkTheme(hEdit2);
+        ApplyDarkTheme(hCopy2);
+        ApplyDarkTheme(hOk);
+    }
 }
 
 LRESULT CALLBACK UrlCopyProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
     case WM_COMMAND:
-        if (LOWORD(wParam) == 2) {
+        if (LOWORD(wParam) == 2 || LOWORD(wParam) == 5) {
+            const std::wstring& src = (LOWORD(wParam) == 2) ? g_url1 : g_url2;
             if (OpenClipboard(hwnd)) {
                 EmptyClipboard();
-                size_t sz = (g_url.size() + 1) * sizeof(wchar_t);
+                size_t sz = (src.size() + 1) * sizeof(wchar_t);
                 HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, sz);
                 if (hMem) {
-                    memcpy(GlobalLock(hMem), g_url.c_str(), sz);
+                    memcpy(GlobalLock(hMem), src.c_str(), sz);
                     GlobalUnlock(hMem);
                     SetClipboardData(CF_UNICODETEXT, hMem);
                 }

--- a/src/upload_dialog.h
+++ b/src/upload_dialog.h
@@ -2,5 +2,5 @@
 #include <windows.h>
 #include <string>
 
-void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstring& url);
+void ShowUrlCopyDialog(HWND parent, const std::wstring& message, const std::wstring& url1, const std::wstring& url2 = L"");
 LRESULT CALLBACK UrlCopyProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -35,7 +35,10 @@ extern double g_cutStartTime;
 extern double g_cutEndTime;
 extern bool g_lastOperationWasExport;
 extern bool g_uploadSuccess;
-extern std::wstring g_uploadedUrl;
+extern std::wstring g_catboxUploadedUrl;
+extern std::wstring g_b2UploadedUrl;
+extern bool g_catboxUploadSuccess;
+extern bool g_b2UploadSuccess;
 extern bool g_autoUpload;
 extern HBRUSH g_hbrBackground;
 extern HFONT g_hFont;
@@ -268,11 +271,15 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             CloseProgressWindow();
             EnableWindow(hwnd, TRUE);
             bool success = wParam != 0;
-            std::wstring provider = g_useCatbox ? L"catbox.moe" : L"Backblaze B2";
             if (success && g_autoUpload && g_uploadSuccess) {
                 std::wstring m = g_lastOperationWasExport ? L"Video successfully exported." : L"Video successfully cut and saved.";
-                m += L"\nUploaded to " + provider + L":";
-                ShowUrlCopyDialog(hwnd, m, g_uploadedUrl);
+                if (g_useCatbox && g_useB2)
+                    m += L"\nUploaded to catbox.moe and Backblaze B2:";
+                else if (g_useCatbox)
+                    m += L"\nUploaded to catbox.moe:";
+                else if (g_useB2)
+                    m += L"\nUploaded to Backblaze B2:";
+                ShowUrlCopyDialog(hwnd, m, g_catboxUploadedUrl, g_b2UploadedUrl);
             } else {
                 const wchar_t* msg;
                 const wchar_t* title;
@@ -281,10 +288,18 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     if (g_autoUpload) {
                         if (g_useCatbox || g_useB2) {
                             std::wstring m = g_lastOperationWasExport ? L"Video successfully exported." : L"Video successfully cut and saved.";
-                            if (g_uploadSuccess)
-                                m += L"\nUploaded to " + provider + L":\n" + g_uploadedUrl;
-                            else
-                                m += L"\nFailed to upload to " + provider + L".";
+                            if (g_useCatbox) {
+                                if (g_catboxUploadSuccess)
+                                    m += L"\nUploaded to catbox.moe:\n" + g_catboxUploadedUrl;
+                                else
+                                    m += L"\nFailed to upload to catbox.moe.";
+                            }
+                            if (g_useB2) {
+                                if (g_b2UploadSuccess)
+                                    m += L"\nUploaded to Backblaze B2:\n" + g_b2UploadedUrl;
+                                else
+                                    m += L"\nFailed to upload to Backblaze B2.";
+                            }
                             msg = m.c_str();
                         } else {
                             msg = g_lastOperationWasExport ? L"Video successfully exported." : L"Video successfully cut and saved.";


### PR DESCRIPTION
## Summary
- remove Catbox success popup that blocked URL window
- allow simultaneous uploads to Catbox and Backblaze B2
- show both URLs with independent copy buttons

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR and libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a5b0244832f8b70f330ac04f0dd