### PR TITLE
Add configurable noise reduction filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(VideoEditor WIN32
     src/timeline.cpp
     src/editing.cpp
     src/utils.cpp
+    src/noise_reduction.cpp
     src/video_decoder.cpp
     src/audio_player.cpp
     src/video_renderer.cpp

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -295,7 +295,7 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
 
     if (track->noiseReduction != NoiseReductionLevel::Disabled)
         ApplyNoiseReduction(outPtr, convertedSamples, m_player->audioChannels,
-                           track->noiseFloor, track->noiseReduction);
+                           track->noiseProfile, track->noiseReduction);
 
     // Store raw samples in track buffer
     {

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -1,5 +1,6 @@
 #include "audio_player.h"
 #include "video_player.h"
+#include "noise_reduction.h"
 #include <chrono>
 #include <limits>
 
@@ -291,6 +292,9 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
                                         (const uint8_t**)track->frame->data, track->frame->nb_samples);
     if (convertedSamples < 0)
         return;
+
+    if (track->noiseReduction)
+        ApplyNoiseReduction(outPtr, convertedSamples, m_player->audioChannels, track->noiseFloor);
 
     // Store raw samples in track buffer
     {

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -293,8 +293,9 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
     if (convertedSamples < 0)
         return;
 
-    if (track->noiseReduction)
-        ApplyNoiseReduction(outPtr, convertedSamples, m_player->audioChannels, track->noiseFloor);
+    if (track->noiseReduction != NoiseReductionLevel::Disabled)
+        ApplyNoiseReduction(outPtr, convertedSamples, m_player->audioChannels,
+                           track->noiseFloor, track->noiseReduction);
 
     // Store raw samples in track buffer
     {

--- a/src/noise_reduction.cpp
+++ b/src/noise_reduction.cpp
@@ -1,11 +1,36 @@
 #include "noise_reduction.h"
 #include <cmath>
 
-void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels, double& noiseFloor)
+void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels,
+                         double& noiseFloor, NoiseReductionLevel level)
 {
-    const double smooth = 0.95;            // smoothing factor for noise floor
-    const double threshold = 1.5;          // noise threshold multiplier
-    const double attenuation = 0.1;        // attenuation factor for noise
+    if (level == NoiseReductionLevel::Disabled)
+        return;
+
+    double smooth = 0.95;
+    double threshold = 1.5;
+    double attenuation = 0.1;
+
+    switch (level)
+    {
+    case NoiseReductionLevel::Low:
+        smooth = 0.98;
+        threshold = 1.2;
+        attenuation = 0.5;
+        break;
+    case NoiseReductionLevel::Normal:
+        smooth = 0.95;
+        threshold = 1.5;
+        attenuation = 0.2;
+        break;
+    case NoiseReductionLevel::High:
+        smooth = 0.90;
+        threshold = 2.0;
+        attenuation = 0.05;
+        break;
+    default:
+        break;
+    }
 
     for (int i = 0; i < sampleCount; ++i)
     {

--- a/src/noise_reduction.cpp
+++ b/src/noise_reduction.cpp
@@ -1,0 +1,31 @@
+#include "noise_reduction.h"
+#include <cmath>
+
+void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels, double& noiseFloor)
+{
+    const double smooth = 0.95;            // smoothing factor for noise floor
+    const double threshold = 1.5;          // noise threshold multiplier
+    const double attenuation = 0.1;        // attenuation factor for noise
+
+    for (int i = 0; i < sampleCount; ++i)
+    {
+        double magnitude = 0.0;
+        for (int ch = 0; ch < channels; ++ch)
+            magnitude += std::abs(samples[i * channels + ch]);
+        magnitude /= channels;
+
+        if (noiseFloor == 0.0)
+            noiseFloor = magnitude;
+        else
+            noiseFloor = smooth * noiseFloor + (1.0 - smooth) * magnitude;
+
+        if (magnitude < noiseFloor * threshold)
+        {
+            for (int ch = 0; ch < channels; ++ch)
+            {
+                samples[i * channels + ch] = static_cast<int16_t>(samples[i * channels + ch] * attenuation);
+            }
+        }
+    }
+}
+

--- a/src/noise_reduction.cpp
+++ b/src/noise_reduction.cpp
@@ -1,56 +1,106 @@
 #include "noise_reduction.h"
 #include <cmath>
+#include <complex>
+#include <vector>
+
+namespace {
+constexpr int kFftSize = 256;
+constexpr double kPi = 3.14159265358979323846;
+
+struct WindowInit {
+    std::vector<double> win;
+    WindowInit() : win(kFftSize) {
+        for (int i = 0; i < kFftSize; ++i)
+            win[i] = 0.5 - 0.5 * std::cos(2.0 * kPi * i / (kFftSize - 1));
+    }
+};
+
+const WindowInit kWindow;
+}
 
 void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels,
-                         double& noiseFloor, NoiseReductionLevel level)
+                         std::vector<double>& noiseProfile, NoiseReductionLevel level)
 {
     if (level == NoiseReductionLevel::Disabled)
         return;
 
-    double smooth = 0.95;
-    double threshold = 1.5;
-    double attenuation = 0.1;
+    if (noiseProfile.size() < kFftSize / 2 + 1)
+        noiseProfile.assign(kFftSize / 2 + 1, 0.0);
 
+    double suppression = 0.0;
+    double update = 0.95;
     switch (level)
     {
     case NoiseReductionLevel::Low:
-        smooth = 0.98;
-        threshold = 1.2;
-        attenuation = 0.5;
+        suppression = 0.3;
+        update = 0.98;
         break;
     case NoiseReductionLevel::Normal:
-        smooth = 0.95;
-        threshold = 1.5;
-        attenuation = 0.2;
+        suppression = 0.5;
+        update = 0.95;
         break;
     case NoiseReductionLevel::High:
-        smooth = 0.90;
-        threshold = 2.0;
-        attenuation = 0.05;
+        suppression = 0.8;
+        update = 0.90;
         break;
     default:
         break;
     }
 
-    for (int i = 0; i < sampleCount; ++i)
+    std::vector<std::complex<double>> spectrum(kFftSize);
+    std::vector<double> magnitudes(kFftSize / 2 + 1);
+
+    for (int pos = 0; pos + kFftSize <= sampleCount; pos += kFftSize)
     {
-        double magnitude = 0.0;
         for (int ch = 0; ch < channels; ++ch)
-            magnitude += std::abs(samples[i * channels + ch]);
-        magnitude /= channels;
-
-        if (noiseFloor == 0.0)
-            noiseFloor = magnitude;
-        else
-            noiseFloor = smooth * noiseFloor + (1.0 - smooth) * magnitude;
-
-        if (magnitude < noiseFloor * threshold)
         {
-            for (int ch = 0; ch < channels; ++ch)
+            for (int n = 0; n < kFftSize; ++n)
             {
-                samples[i * channels + ch] = static_cast<int16_t>(samples[i * channels + ch] * attenuation);
+                double s = samples[(pos + n) * channels + ch];
+                spectrum[n] = s * kWindow.win[n];
+            }
+
+            // DFT
+            for (int k = 0; k < kFftSize; ++k)
+            {
+                std::complex<double> sum(0.0, 0.0);
+                for (int n = 0; n < kFftSize; ++n)
+                {
+                    double angle = -2.0 * kPi * k * n / kFftSize;
+                    sum += spectrum[n] * std::complex<double>(std::cos(angle), std::sin(angle));
+                }
+                spectrum[k] = sum;
+            }
+
+            for (int k = 0; k <= kFftSize / 2; ++k)
+            {
+                magnitudes[k] = std::abs(spectrum[k]);
+                noiseProfile[k] = update * noiseProfile[k] + (1.0 - update) * magnitudes[k];
+                double cleanMag = magnitudes[k] - noiseProfile[k];
+                if (cleanMag < 0.0)
+                    cleanMag = 0.0;
+                double targetMag = noiseProfile[k] + cleanMag * (1.0 - suppression);
+                double gain = targetMag / (magnitudes[k] + 1e-9);
+                spectrum[k] *= gain;
+                if (k > 0 && k < kFftSize / 2)
+                    spectrum[kFftSize - k] = std::conj(spectrum[k]);
+            }
+
+            // Inverse DFT
+            for (int n = 0; n < kFftSize; ++n)
+            {
+                std::complex<double> sum(0.0, 0.0);
+                for (int k = 0; k < kFftSize; ++k)
+                {
+                    double angle = 2.0 * kPi * k * n / kFftSize;
+                    sum += spectrum[k] * std::complex<double>(std::cos(angle), std::sin(angle));
+                }
+                double val = sum.real() / kFftSize;
+                val /= kWindow.win[n];
+                if (val > 32767.0) val = 32767.0;
+                if (val < -32768.0) val = -32768.0;
+                samples[(pos + n) * channels + ch] = static_cast<int16_t>(val);
             }
         }
     }
 }
-

--- a/src/noise_reduction.h
+++ b/src/noise_reduction.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 // Levels of noise reduction intensity
 enum class NoiseReductionLevel {
@@ -10,12 +11,12 @@ enum class NoiseReductionLevel {
     High
 };
 
-// Apply simple noise reduction in-place on audio samples.
+// Apply spectral noise reduction in-place on audio samples.
 // samples: pointer to interleaved int16 samples
 // sampleCount: number of frames (per channel)
 // channels: number of audio channels
-// noiseFloor: running estimate of noise level (updated in-place)
+// noiseProfile: running estimate of noise spectrum (updated in-place)
 // level: reduction intensity
 void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels,
-                         double& noiseFloor, NoiseReductionLevel level);
+                         std::vector<double>& noiseProfile, NoiseReductionLevel level);
 

--- a/src/noise_reduction.h
+++ b/src/noise_reduction.h
@@ -2,10 +2,20 @@
 
 #include <cstdint>
 
+// Levels of noise reduction intensity
+enum class NoiseReductionLevel {
+    Disabled = 0,
+    Low,
+    Normal,
+    High
+};
+
 // Apply simple noise reduction in-place on audio samples.
 // samples: pointer to interleaved int16 samples
 // sampleCount: number of frames (per channel)
 // channels: number of audio channels
 // noiseFloor: running estimate of noise level (updated in-place)
-void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels, double& noiseFloor);
+// level: reduction intensity
+void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels,
+                         double& noiseFloor, NoiseReductionLevel level);
 

--- a/src/noise_reduction.h
+++ b/src/noise_reduction.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+// Apply simple noise reduction in-place on audio samples.
+// samples: pointer to interleaved int16 samples
+// sampleCount: number of frames (per channel)
+// channels: number of audio channels
+// noiseFloor: running estimate of noise level (updated in-place)
+void ApplyNoiseReduction(int16_t* samples, int sampleCount, int channels, double& noiseFloor);
+

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <commctrl.h>
 #include <libavutil/frame.h>
+#include "noise_reduction.h"
 
 VideoCutter::VideoCutter(VideoPlayer* player) : m_player(player) {}
 
@@ -71,6 +72,8 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
         SwrContext* swrCtx;
         AVFrame* frame;
         std::deque<int16_t> buffer;
+        bool noiseReduction;
+        double noiseFloor;
     };
     std::vector<MergeTrack> mergeTracks;
     AVCodecContext* aEncCtx = nullptr;
@@ -219,6 +222,17 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
             av_opt_set_chlayout(mt.swrCtx, "out_chlayout", &out_ch, 0);
             swr_init(mt.swrCtx);
             mt.frame = av_frame_alloc();
+            mt.noiseReduction = false;
+            mt.noiseFloor = 0.0;
+            for (const auto& t : m_player->audioTracks)
+            {
+                if (t->streamIndex == i)
+                {
+                    mt.noiseReduction = t->noiseReduction;
+                    mt.noiseFloor = t->noiseFloor;
+                    break;
+                }
+            }
             mergeTracks.push_back(mt);
             continue; // output stream created later
         } else {
@@ -379,6 +393,8 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                         int conv = swr_convert(mt.swrCtx, outArr, outSamples,
                                               (const uint8_t**)mt.frame->data,
                                               mt.frame->nb_samples);
+                        if (mt.noiseReduction)
+                            ApplyNoiseReduction(tmp.data(), conv, 2, mt.noiseFloor);
                         mt.buffer.insert(mt.buffer.end(), tmp.begin(),
                                           tmp.begin() + conv * 2);
                     }

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -72,7 +72,7 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
         SwrContext* swrCtx;
         AVFrame* frame;
         std::deque<int16_t> buffer;
-        bool noiseReduction;
+        NoiseReductionLevel noiseReduction;
         double noiseFloor;
     };
     std::vector<MergeTrack> mergeTracks;
@@ -222,7 +222,7 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
             av_opt_set_chlayout(mt.swrCtx, "out_chlayout", &out_ch, 0);
             swr_init(mt.swrCtx);
             mt.frame = av_frame_alloc();
-            mt.noiseReduction = false;
+            mt.noiseReduction = NoiseReductionLevel::Disabled;
             mt.noiseFloor = 0.0;
             for (const auto& t : m_player->audioTracks)
             {
@@ -393,8 +393,8 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                         int conv = swr_convert(mt.swrCtx, outArr, outSamples,
                                               (const uint8_t**)mt.frame->data,
                                               mt.frame->nb_samples);
-                        if (mt.noiseReduction)
-                            ApplyNoiseReduction(tmp.data(), conv, 2, mt.noiseFloor);
+                        if (mt.noiseReduction != NoiseReductionLevel::Disabled)
+                            ApplyNoiseReduction(tmp.data(), conv, 2, mt.noiseFloor, mt.noiseReduction);
                         mt.buffer.insert(mt.buffer.end(), tmp.begin(),
                                           tmp.begin() + conv * 2);
                     }

--- a/src/video_cutter.cpp
+++ b/src/video_cutter.cpp
@@ -73,7 +73,7 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
         AVFrame* frame;
         std::deque<int16_t> buffer;
         NoiseReductionLevel noiseReduction;
-        double noiseFloor;
+        std::vector<double> noiseProfile;
     };
     std::vector<MergeTrack> mergeTracks;
     AVCodecContext* aEncCtx = nullptr;
@@ -223,13 +223,13 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
             swr_init(mt.swrCtx);
             mt.frame = av_frame_alloc();
             mt.noiseReduction = NoiseReductionLevel::Disabled;
-            mt.noiseFloor = 0.0;
+            mt.noiseProfile.clear();
             for (const auto& t : m_player->audioTracks)
             {
                 if (t->streamIndex == i)
                 {
                     mt.noiseReduction = t->noiseReduction;
-                    mt.noiseFloor = t->noiseFloor;
+                    mt.noiseProfile = t->noiseProfile;
                     break;
                 }
             }
@@ -394,7 +394,7 @@ bool VideoCutter::CutVideo(const std::wstring& outputFilename, double startTime,
                                               (const uint8_t**)mt.frame->data,
                                               mt.frame->nb_samples);
                         if (mt.noiseReduction != NoiseReductionLevel::Disabled)
-                            ApplyNoiseReduction(tmp.data(), conv, 2, mt.noiseFloor, mt.noiseReduction);
+                            ApplyNoiseReduction(tmp.data(), conv, 2, mt.noiseProfile, mt.noiseReduction);
                         mt.buffer.insert(mt.buffer.end(), tmp.begin(),
                                           tmp.begin() + conv * 2);
                     }

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -378,19 +378,19 @@ void VideoPlayer::SetAudioTrackVolume(int trackIndex, float volume)
     audioTracks[trackIndex]->volume = clampedVolume;
 }
 
-bool VideoPlayer::IsNoiseReductionEnabled(int trackIndex) const
+NoiseReductionLevel VideoPlayer::GetNoiseReductionLevel(int trackIndex) const
 {
     if (trackIndex < 0 || trackIndex >= static_cast<int>(audioTracks.size()))
-        return false;
+        return NoiseReductionLevel::Disabled;
     return audioTracks[trackIndex]->noiseReduction;
 }
 
-void VideoPlayer::SetNoiseReductionEnabled(int trackIndex, bool enabled)
+void VideoPlayer::SetNoiseReductionLevel(int trackIndex, NoiseReductionLevel level)
 {
     if (trackIndex < 0 || trackIndex >= static_cast<int>(audioTracks.size()))
         return;
-    audioTracks[trackIndex]->noiseReduction = enabled;
-    if (!enabled)
+    audioTracks[trackIndex]->noiseReduction = level;
+    if (level == NoiseReductionLevel::Disabled)
         audioTracks[trackIndex]->noiseFloor = 0.0;
 }
 

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -378,6 +378,22 @@ void VideoPlayer::SetAudioTrackVolume(int trackIndex, float volume)
     audioTracks[trackIndex]->volume = clampedVolume;
 }
 
+bool VideoPlayer::IsNoiseReductionEnabled(int trackIndex) const
+{
+    if (trackIndex < 0 || trackIndex >= static_cast<int>(audioTracks.size()))
+        return false;
+    return audioTracks[trackIndex]->noiseReduction;
+}
+
+void VideoPlayer::SetNoiseReductionEnabled(int trackIndex, bool enabled)
+{
+    if (trackIndex < 0 || trackIndex >= static_cast<int>(audioTracks.size()))
+        return;
+    audioTracks[trackIndex]->noiseReduction = enabled;
+    if (!enabled)
+        audioTracks[trackIndex]->noiseFloor = 0.0;
+}
+
 void VideoPlayer::SetMasterVolume(float volume)
 {
     m_audioPlayer->SetMasterVolume(volume);

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -391,7 +391,7 @@ void VideoPlayer::SetNoiseReductionLevel(int trackIndex, NoiseReductionLevel lev
         return;
     audioTracks[trackIndex]->noiseReduction = level;
     if (level == NoiseReductionLevel::Disabled)
-        audioTracks[trackIndex]->noiseFloor = 0.0;
+        audioTracks[trackIndex]->noiseProfile.clear();
 }
 
 void VideoPlayer::SetMasterVolume(float volume)

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -49,14 +49,17 @@ struct AudioTrack {
     SwrContext *swrContext;
     AVFrame *frame;
     bool isMuted;
+    bool noiseReduction;
     float volume;
     std::string name;
     std::deque<int16_t> buffer;
     std::vector<int16_t> resampleBuffer;
     double bufferPts;
+    double noiseFloor;
 
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
-                   frame(nullptr), isMuted(false), volume(1.0f), bufferPts(0.0) {}
+                   frame(nullptr), isMuted(false), noiseReduction(false),
+                   volume(1.0f), bufferPts(0.0), noiseFloor(0.0) {}
 };
 
 class VideoPlayer
@@ -178,6 +181,8 @@ public:
     void SetAudioTrackMuted(int trackIndex, bool muted);
     float GetAudioTrackVolume(int trackIndex) const;
     void SetAudioTrackVolume(int trackIndex, float volume);
+    bool IsNoiseReductionEnabled(int trackIndex) const;
+    void SetNoiseReductionEnabled(int trackIndex, bool enabled);
     void SetMasterVolume(float volume);
     bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime,
                   bool mergeAudio, bool convertH264, bool useNvenc,

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -57,11 +57,11 @@ struct AudioTrack {
     std::deque<int16_t> buffer;
     std::vector<int16_t> resampleBuffer;
     double bufferPts;
-    double noiseFloor;
+    std::vector<double> noiseProfile;
 
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
                    frame(nullptr), isMuted(false), noiseReduction(NoiseReductionLevel::Disabled),
-                   volume(1.0f), bufferPts(0.0), noiseFloor(0.0) {}
+                   volume(1.0f), bufferPts(0.0) {}
 };
 
 class VideoPlayer

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -32,6 +32,8 @@ extern "C"
 #include <chrono>
 #include <limits>
 
+#include "noise_reduction.h"
+
 // Audio output using Windows Audio Session API (WASAPI)
 #include <mmdeviceapi.h>
 #include <audioclient.h>
@@ -49,7 +51,7 @@ struct AudioTrack {
     SwrContext *swrContext;
     AVFrame *frame;
     bool isMuted;
-    bool noiseReduction;
+    NoiseReductionLevel noiseReduction;
     float volume;
     std::string name;
     std::deque<int16_t> buffer;
@@ -58,7 +60,7 @@ struct AudioTrack {
     double noiseFloor;
 
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
-                   frame(nullptr), isMuted(false), noiseReduction(false),
+                   frame(nullptr), isMuted(false), noiseReduction(NoiseReductionLevel::Disabled),
                    volume(1.0f), bufferPts(0.0), noiseFloor(0.0) {}
 };
 
@@ -181,8 +183,8 @@ public:
     void SetAudioTrackMuted(int trackIndex, bool muted);
     float GetAudioTrackVolume(int trackIndex) const;
     void SetAudioTrackVolume(int trackIndex, float volume);
-    bool IsNoiseReductionEnabled(int trackIndex) const;
-    void SetNoiseReductionEnabled(int trackIndex, bool enabled);
+    NoiseReductionLevel GetNoiseReductionLevel(int trackIndex) const;
+    void SetNoiseReductionLevel(int trackIndex, NoiseReductionLevel level);
     void SetMasterVolume(float volume);
     bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime,
                   bool mergeAudio, bool convertH264, bool useNvenc,

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -44,6 +44,12 @@ extern HBRUSH g_hbrBackground;
 extern HFONT g_hFont;
 extern COLORREF g_textColor;
 
+// Context menu IDs for noise reduction levels
+#define ID_NR_DISABLED 2001
+#define ID_NR_LOW      2002
+#define ID_NR_NORMAL   2003
+#define ID_NR_HIGH     2004
+
 
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -119,6 +125,22 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         case 1025: // ID_RADIO_USE_SIZE
             UpdateControls();
             break;
+        case ID_NR_DISABLED:
+        case ID_NR_LOW:
+        case ID_NR_NORMAL:
+        case ID_NR_HIGH:
+        {
+            int sel = (int)SendMessage(g_hListBoxAudioTracks, LB_GETCURSEL, 0, 0);
+            if (sel != LB_ERR && g_videoPlayer)
+            {
+                NoiseReductionLevel level = NoiseReductionLevel::Disabled;
+                if (LOWORD(wParam) == ID_NR_LOW) level = NoiseReductionLevel::Low;
+                else if (LOWORD(wParam) == ID_NR_NORMAL) level = NoiseReductionLevel::Normal;
+                else if (LOWORD(wParam) == ID_NR_HIGH) level = NoiseReductionLevel::High;
+                g_videoPlayer->SetNoiseReductionLevel(sel, level);
+            }
+            break;
+        }
         }
 
         if ((HWND)lParam == g_hEditStartTime && HIWORD(wParam) == EN_KILLFOCUS)
@@ -178,6 +200,25 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (HIWORD(wParam) == LBN_SELCHANGE && (HWND)lParam == g_hListBoxAudioTracks)
         {
             OnAudioTrackSelectionChanged();
+        }
+        break;
+
+    case WM_CONTEXTMENU:
+        if ((HWND)wParam == g_hListBoxAudioTracks && g_videoPlayer)
+        {
+            int sel = (int)SendMessage(g_hListBoxAudioTracks, LB_GETCURSEL, 0, 0);
+            if (sel != LB_ERR)
+            {
+                HMENU menu = CreatePopupMenu();
+                NoiseReductionLevel level = g_videoPlayer->GetNoiseReductionLevel(sel);
+                AppendMenu(menu, MF_STRING | (level == NoiseReductionLevel::Disabled ? MF_CHECKED : 0), ID_NR_DISABLED, L"Disabled");
+                AppendMenu(menu, MF_STRING | (level == NoiseReductionLevel::Low ? MF_CHECKED : 0), ID_NR_LOW, L"Low");
+                AppendMenu(menu, MF_STRING | (level == NoiseReductionLevel::Normal ? MF_CHECKED : 0), ID_NR_NORMAL, L"Normal");
+                AppendMenu(menu, MF_STRING | (level == NoiseReductionLevel::High ? MF_CHECKED : 0), ID_NR_HIGH, L"High");
+                TrackPopupMenu(menu, TPM_RIGHTBUTTON, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam), 0, hwnd, NULL);
+                DestroyMenu(menu);
+            }
+            return 0;
         }
         break;
 

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -8,6 +8,7 @@
 #include "editing.h"
 #include "upload_dialog.h"
 #include "utils.h"
+#include <windowsx.h>
 
 // Forward declarations for functions in other files
 void ApplyDarkTheme(HWND hwnd);


### PR DESCRIPTION
## Summary
- Introduce simple noise-reduction module for audio samples
- Allow enabling noise reduction per audio track and apply during playback/export
- Wire filter into audio mixing and video cutting routines

## Testing
- `cmake -S . -B build` (fails: FFMPEG_INCLUDE_DIR not found)
- `cmake --build build` (fails: windows.h: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68a79b3eded8832f93f6f915aad862d0