### PR TITLE
Add voice isolation preview using RNNoise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_compile_definitions(UNICODE _UNICODE)
 # Default paths (can override with -DFFMPEG_ROOT=... or -DCURL_ROOT=...)
 set(FFMPEG_ROOT "${CMAKE_SOURCE_DIR}/third_party/ffmpeg" CACHE PATH "Path to FFmpeg installation")
 set(CURL_ROOT   "${CMAKE_SOURCE_DIR}/vendor/libcurl" CACHE PATH "Path to libcurl installation")
+set(RNNOISE_ROOT "${CMAKE_SOURCE_DIR}/third_party/rnnoise" CACHE PATH "Path to rnnoise installation")
 
 # ==== FIND FFmpeg ====
 find_path(FFMPEG_INCLUDE_DIR
@@ -41,6 +42,16 @@ find_library(AVFORMAT_LIBRARY   NAMES avformat   PATHS ${FFMPEG_ROOT}/lib NO_DEF
 find_library(AVUTIL_LIBRARY     NAMES avutil     PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
 find_library(SWSCALE_LIBRARY    NAMES swscale    PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
 find_library(SWRESAMPLE_LIBRARY NAMES swresample PATHS ${FFMPEG_ROOT}/lib NO_DEFAULT_PATH)
+
+# ==== FIND rnnoise ====
+find_path(RNNOISE_INCLUDE_DIR
+    NAMES rnnoise.h
+    PATHS ${RNNOISE_ROOT}/include
+    NO_DEFAULT_PATH)
+find_library(RNNOISE_LIBRARY NAMES rnnoise PATHS ${RNNOISE_ROOT}/lib NO_DEFAULT_PATH)
+
+message(STATUS ">> rnnoise include: ${RNNOISE_INCLUDE_DIR}")
+message(STATUS ">> rnnoise lib: ${RNNOISE_LIBRARY}")
 
 message(STATUS ">> FFmpeg include: ${FFMPEG_INCLUDE_DIR}")
 message(STATUS ">> avcodec lib:    ${AVCODEC_LIBRARY}")
@@ -105,6 +116,7 @@ add_executable(VideoEditor WIN32
 target_include_directories(VideoEditor PRIVATE
     src
     ${FFMPEG_INCLUDE_DIR}
+    ${RNNOISE_INCLUDE_DIR}
 )
 
 # ==== WINDOWS PLATFORM LIBS ====
@@ -135,6 +147,7 @@ target_link_libraries(VideoEditor PRIVATE
     ${FFMPEG_LIBS}
     VENDOR_LIBCURL
     $<$<BOOL:NOT USE_STATIC_FFMPEG>:VENDOR_ZLIB>
+    ${RNNOISE_LIBRARY}
 )
 
 # ==== COPY FFmpeg DLLS (dynamic build) ====

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -305,12 +305,12 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
                 track->bufferPts = framePts - m_player->startTimeOffset;
             for (int i = 0; i < convertedSamples; ++i)
             {
-                int16_t *framePtr = outPtr + i * m_player->audioChannels;
+                int16_t* framePtr = outPtr + i * m_player->audioChannels;
                 float sampleMono;
                 if (m_player->audioChannels == 1)
-                    sampleMono = framePtr[0] / 32768.0f;
+                    sampleMono = static_cast<float>(framePtr[0]);
                 else
-                    sampleMono = (framePtr[0] + framePtr[1]) / (2.0f * 32768.0f);
+                    sampleMono = 0.5f * (static_cast<float>(framePtr[0]) + static_cast<float>(framePtr[1]));
                 track->rnnoiseBuffer.push_back(sampleMono);
                 if (static_cast<int>(track->rnnoiseBuffer.size()) >= frameSize)
                 {
@@ -318,7 +318,7 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
                     rnnoise_process_frame(track->rnnoiseState, denoised.data(), track->rnnoiseBuffer.data());
                     for (int j = 0; j < frameSize; ++j)
                     {
-                        int val = static_cast<int>(denoised[j] * 32768.0f);
+                        int val = static_cast<int>(denoised[j]);
                         if (val > 32767) val = 32767;
                         if (val < -32768) val = -32768;
                         int16_t s = static_cast<int16_t>(val);

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -70,6 +70,7 @@ bool AudioPlayer::Initialize() {
     // Update audio configuration to match the initialized format
     m_player->audioSampleRate = m_player->audioFormat->nSamplesPerSec;
     m_player->audioChannels = m_player->audioFormat->nChannels;
+    m_player->audioIsFloat = (m_player->audioFormat->wBitsPerSample == 32);
 
     hr = m_player->audioClient->GetBufferSize(&m_player->bufferFrameCount);
     if (FAILED(hr))
@@ -434,44 +435,83 @@ void AudioPlayer::AudioThreadFunction() {
 }
 
 void AudioPlayer::MixAudioTracks(uint8_t* outputBuffer, int frameCount, double startPts) {
-    memset(outputBuffer, 0, frameCount * m_player->audioChannels * sizeof(int16_t));
-    int16_t *out = reinterpret_cast<int16_t*>(outputBuffer);
+    int bytesPerSample = m_player->audioIsFloat ? sizeof(float) : sizeof(int16_t);
+    memset(outputBuffer, 0, frameCount * m_player->audioChannels * bytesPerSample);
 
     for (int frame = 0; frame < frameCount; ++frame)
     {
         double samplePts = startPts + frame / static_cast<double>(m_player->audioSampleRate);
-        std::vector<int32_t> mix(m_player->audioChannels, 0);
-        for (auto& track : m_player->audioTracks)
+        if (m_player->audioIsFloat)
         {
-            if (track->isMuted)
-                continue;
-
-            // Drop samples that are earlier than the desired timestamp
-            while (!track->buffer.empty() &&
-                   track->bufferPts + 1.0 / m_player->audioSampleRate <= samplePts)
+            std::vector<float> mix(m_player->audioChannels, 0.0f);
+            for (auto& track : m_player->audioTracks)
             {
-                for (int ch = 0; ch < m_player->audioChannels && !track->buffer.empty(); ++ch)
-                    track->buffer.pop_front();
-                track->bufferPts += 1.0 / m_player->audioSampleRate;
-            }
+                if (track->isMuted)
+                    continue;
 
-            if (track->buffer.size() >= static_cast<size_t>(m_player->audioChannels))
-            {
-                for (int ch = 0; ch < m_player->audioChannels; ++ch)
+                while (!track->buffer.empty() &&
+                       track->bufferPts + 1.0 / m_player->audioSampleRate <= samplePts)
                 {
-                    int16_t val = track->buffer.front();
-                    track->buffer.pop_front();
-                    mix[ch] += static_cast<int32_t>(val * track->volume);
+                    for (int ch = 0; ch < m_player->audioChannels && !track->buffer.empty(); ++ch)
+                        track->buffer.pop_front();
+                    track->bufferPts += 1.0 / m_player->audioSampleRate;
                 }
-                track->bufferPts += 1.0 / m_player->audioSampleRate;
+
+                if (track->buffer.size() >= static_cast<size_t>(m_player->audioChannels))
+                {
+                    for (int ch = 0; ch < m_player->audioChannels; ++ch)
+                    {
+                        int16_t val = track->buffer.front();
+                        track->buffer.pop_front();
+                        mix[ch] += (val / 32768.0f) * track->volume;
+                    }
+                    track->bufferPts += 1.0 / m_player->audioSampleRate;
+                }
+            }
+            float *out = reinterpret_cast<float*>(outputBuffer);
+            for (int ch = 0; ch < m_player->audioChannels; ++ch)
+            {
+                float v = mix[ch];
+                if (v > 1.0f) v = 1.0f;
+                if (v < -1.0f) v = -1.0f;
+                out[frame * m_player->audioChannels + ch] = v;
             }
         }
-        for (int ch = 0; ch < m_player->audioChannels; ++ch)
+        else
         {
-            int32_t v = mix[ch];
-            if (v > 32767) v = 32767;
-            if (v < -32768) v = -32768;
-            out[frame * m_player->audioChannels + ch] = static_cast<int16_t>(v);
+            std::vector<int32_t> mix(m_player->audioChannels, 0);
+            for (auto& track : m_player->audioTracks)
+            {
+                if (track->isMuted)
+                    continue;
+
+                while (!track->buffer.empty() &&
+                       track->bufferPts + 1.0 / m_player->audioSampleRate <= samplePts)
+                {
+                    for (int ch = 0; ch < m_player->audioChannels && !track->buffer.empty(); ++ch)
+                        track->buffer.pop_front();
+                    track->bufferPts += 1.0 / m_player->audioSampleRate;
+                }
+
+                if (track->buffer.size() >= static_cast<size_t>(m_player->audioChannels))
+                {
+                    for (int ch = 0; ch < m_player->audioChannels; ++ch)
+                    {
+                        int16_t val = track->buffer.front();
+                        track->buffer.pop_front();
+                        mix[ch] += static_cast<int32_t>(val * track->volume);
+                    }
+                    track->bufferPts += 1.0 / m_player->audioSampleRate;
+                }
+            }
+            int16_t *out = reinterpret_cast<int16_t*>(outputBuffer);
+            for (int ch = 0; ch < m_player->audioChannels; ++ch)
+            {
+                int32_t v = mix[ch];
+                if (v > 32767) v = 32767;
+                if (v < -32768) v = -32768;
+                out[frame * m_player->audioChannels + ch] = static_cast<int16_t>(v);
+            }
         }
     }
 }

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -1,5 +1,6 @@
 #include "audio_player.h"
 #include "video_player.h"
+#include "rnnoise.h"
 #include <chrono>
 #include <limits>
 
@@ -214,8 +215,13 @@ void AudioPlayer::CleanupTracks() {
             av_frame_free(&track->frame);
         if (track->codecContext)
             avcodec_free_context(&track->codecContext);
+        if (track->rnnoiseState)
+            rnnoise_destroy(track->rnnoiseState);
+        track->rnnoiseState = nullptr;
+        track->rnnoiseBuffer.clear();
         track->buffer.clear();
         track->bufferPts = 0.0;
+        track->voiceIsolation = false;
     }
     m_player->audioTracks.clear();
 }
@@ -292,14 +298,47 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
     if (convertedSamples < 0)
         return;
 
-    // Store raw samples in track buffer
+    // Store processed samples in track buffer
     {
         std::lock_guard<std::mutex> lock(m_player->audioMutex);
-        if (track->buffer.empty())
-            track->bufferPts = framePts - m_player->startTimeOffset;
-        track->buffer.insert(track->buffer.end(),
-                             outPtr,
-                             outPtr + convertedSamples * m_player->audioChannels);
+        if (track->voiceIsolation && track->rnnoiseState)
+        {
+            if (track->buffer.empty() && track->rnnoiseBuffer.empty())
+                track->bufferPts = framePts - m_player->startTimeOffset;
+            for (int i = 0; i < convertedSamples; ++i)
+            {
+                int16_t *framePtr = outPtr + i * m_player->audioChannels;
+                float sampleMono;
+                if (m_player->audioChannels == 1)
+                    sampleMono = framePtr[0] / 32768.0f;
+                else
+                    sampleMono = (framePtr[0] + framePtr[1]) / (2.0f * 32768.0f);
+                track->rnnoiseBuffer.push_back(sampleMono);
+                if (track->rnnoiseBuffer.size() >= RNNOISE_FRAME_SIZE)
+                {
+                    float denoised[RNNOISE_FRAME_SIZE];
+                    rnnoise_process_frame(track->rnnoiseState, denoised, track->rnnoiseBuffer.data());
+                    for (int j = 0; j < RNNOISE_FRAME_SIZE; ++j)
+                    {
+                        int val = static_cast<int>(denoised[j] * 32768.0f);
+                        if (val > 32767) val = 32767;
+                        if (val < -32768) val = -32768;
+                        int16_t s = static_cast<int16_t>(val);
+                        for (int ch = 0; ch < m_player->audioChannels; ++ch)
+                            track->buffer.push_back(s);
+                    }
+                    track->rnnoiseBuffer.erase(track->rnnoiseBuffer.begin(), track->rnnoiseBuffer.begin() + RNNOISE_FRAME_SIZE);
+                }
+            }
+        }
+        else
+        {
+            if (track->buffer.empty())
+                track->bufferPts = framePts - m_player->startTimeOffset;
+            track->buffer.insert(track->buffer.end(),
+                                 outPtr,
+                                 outPtr + convertedSamples * m_player->audioChannels);
+        }
     }
     m_player->audioCondition.notify_one();
 }

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -3,6 +3,7 @@
 #include "rnnoise.h"
 #include <chrono>
 #include <limits>
+#include <vector>
 
 AudioPlayer::AudioPlayer(VideoPlayer* player) : m_player(player), m_framesWritten(0) {}
 
@@ -35,11 +36,11 @@ bool AudioPlayer::Initialize() {
     if (FAILED(hr))
         return false;
 
-    // Set up our desired format (16-bit stereo at 44.1kHz)
+    // Set up our desired format (16-bit stereo at 48kHz) so RNNoise receives 48kHz input
     m_player->audioFormat = (WAVEFORMATEX*)CoTaskMemAlloc(sizeof(WAVEFORMATEX));
     m_player->audioFormat->wFormatTag = WAVE_FORMAT_PCM;
     m_player->audioFormat->nChannels = 2;
-    m_player->audioFormat->nSamplesPerSec = 44100;
+    m_player->audioFormat->nSamplesPerSec = 48000;
     m_player->audioFormat->wBitsPerSample = 16;
     m_player->audioFormat->nBlockAlign = (m_player->audioFormat->nChannels * m_player->audioFormat->wBitsPerSample) / 8;
     m_player->audioFormat->nAvgBytesPerSec = m_player->audioFormat->nSamplesPerSec * m_player->audioFormat->nBlockAlign;
@@ -303,6 +304,7 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
         std::lock_guard<std::mutex> lock(m_player->audioMutex);
         if (track->voiceIsolation && track->rnnoiseState)
         {
+            const int frameSize = rnnoise_get_frame_size();
             if (track->buffer.empty() && track->rnnoiseBuffer.empty())
                 track->bufferPts = framePts - m_player->startTimeOffset;
             for (int i = 0; i < convertedSamples; ++i)
@@ -314,11 +316,11 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
                 else
                     sampleMono = (framePtr[0] + framePtr[1]) / (2.0f * 32768.0f);
                 track->rnnoiseBuffer.push_back(sampleMono);
-                if (track->rnnoiseBuffer.size() >= RNNOISE_FRAME_SIZE)
+                if (static_cast<int>(track->rnnoiseBuffer.size()) >= frameSize)
                 {
-                    float denoised[RNNOISE_FRAME_SIZE];
-                    rnnoise_process_frame(track->rnnoiseState, denoised, track->rnnoiseBuffer.data());
-                    for (int j = 0; j < RNNOISE_FRAME_SIZE; ++j)
+                    std::vector<float> denoised(frameSize);
+                    rnnoise_process_frame(track->rnnoiseState, denoised.data(), track->rnnoiseBuffer.data());
+                    for (int j = 0; j < frameSize; ++j)
                     {
                         int val = static_cast<int>(denoised[j] * 32768.0f);
                         if (val > 32767) val = 32767;
@@ -327,7 +329,7 @@ void AudioPlayer::ProcessFrame(AVPacket* audioPacket) {
                         for (int ch = 0; ch < m_player->audioChannels; ++ch)
                             track->buffer.push_back(s);
                     }
-                    track->rnnoiseBuffer.erase(track->rnnoiseBuffer.begin(), track->rnnoiseBuffer.begin() + RNNOISE_FRAME_SIZE);
+                    track->rnnoiseBuffer.erase(track->rnnoiseBuffer.begin(), track->rnnoiseBuffer.begin() + frameSize);
                 }
             }
         }

--- a/src/audio_player.cpp
+++ b/src/audio_player.cpp
@@ -4,6 +4,8 @@
 #include <chrono>
 #include <limits>
 #include <vector>
+#include <mmreg.h>
+#include <ksmedia.h>
 
 AudioPlayer::AudioPlayer(VideoPlayer* player) : m_player(player), m_framesWritten(0) {}
 
@@ -30,21 +32,11 @@ bool AudioPlayer::Initialize() {
     if (FAILED(hr))
         return false;
 
-    // Get the default audio format
+    // Get the default audio format and initialize using it
     WAVEFORMATEX *deviceFormat = nullptr;
     hr = m_player->audioClient->GetMixFormat(&deviceFormat);
     if (FAILED(hr))
         return false;
-
-    // Set up our desired format (16-bit stereo at 48kHz) so RNNoise receives 48kHz input
-    m_player->audioFormat = (WAVEFORMATEX*)CoTaskMemAlloc(sizeof(WAVEFORMATEX));
-    m_player->audioFormat->wFormatTag = WAVE_FORMAT_PCM;
-    m_player->audioFormat->nChannels = 2;
-    m_player->audioFormat->nSamplesPerSec = 48000;
-    m_player->audioFormat->wBitsPerSample = 16;
-    m_player->audioFormat->nBlockAlign = (m_player->audioFormat->nChannels * m_player->audioFormat->wBitsPerSample) / 8;
-    m_player->audioFormat->nAvgBytesPerSec = m_player->audioFormat->nSamplesPerSec * m_player->audioFormat->nBlockAlign;
-    m_player->audioFormat->cbSize = 0;
 
     REFERENCE_TIME devicePeriod = 0;
     hr = m_player->audioClient->GetDevicePeriod(nullptr, &devicePeriod);
@@ -52,25 +44,28 @@ bool AudioPlayer::Initialize() {
         devicePeriod = 100000; // fall back to 10ms
     REFERENCE_TIME bufferDuration = devicePeriod * 4; // approx 40ms
 
+    m_player->audioFormat = deviceFormat;
     hr = m_player->audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, bufferDuration, 0, m_player->audioFormat, nullptr);
     if (FAILED(hr))
-    {
-        // Try with device format if our format fails
-        CoTaskMemFree(m_player->audioFormat);
-        m_player->audioFormat = deviceFormat;
-        hr = m_player->audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, bufferDuration, 0, m_player->audioFormat, nullptr);
-        if (FAILED(hr))
-            return false;
-    }
-    else
-    {
-        CoTaskMemFree(deviceFormat);
-    }
+        return false;
 
     // Update audio configuration to match the initialized format
     m_player->audioSampleRate = m_player->audioFormat->nSamplesPerSec;
     m_player->audioChannels = m_player->audioFormat->nChannels;
-    m_player->audioIsFloat = (m_player->audioFormat->wBitsPerSample == 32);
+
+    bool isFloat = false;
+    if (m_player->audioFormat->wFormatTag == WAVE_FORMAT_IEEE_FLOAT)
+    {
+        isFloat = true;
+    }
+    else if (m_player->audioFormat->wFormatTag == WAVE_FORMAT_EXTENSIBLE)
+    {
+        WAVEFORMATEXTENSIBLE *ext = reinterpret_cast<WAVEFORMATEXTENSIBLE*>(m_player->audioFormat);
+        if (IsEqualGUID(ext->SubFormat, KSDATAFORMAT_SUBTYPE_IEEE_FLOAT))
+            isFloat = true;
+    }
+    m_player->audioIsFloat = isFloat;
+    m_player->audioSampleFormat = isFloat ? AV_SAMPLE_FMT_FLT : AV_SAMPLE_FMT_S16;
 
     hr = m_player->audioClient->GetBufferSize(&m_player->bufferFrameCount);
     if (FAILED(hr))
@@ -435,7 +430,7 @@ void AudioPlayer::AudioThreadFunction() {
 }
 
 void AudioPlayer::MixAudioTracks(uint8_t* outputBuffer, int frameCount, double startPts) {
-    int bytesPerSample = m_player->audioIsFloat ? sizeof(float) : sizeof(int16_t);
+    int bytesPerSample = m_player->audioFormat->wBitsPerSample / 8;
     memset(outputBuffer, 0, frameCount * m_player->audioChannels * bytesPerSample);
 
     for (int frame = 0; frame < frameCount; ++frame)
@@ -475,6 +470,42 @@ void AudioPlayer::MixAudioTracks(uint8_t* outputBuffer, int frameCount, double s
                 if (v > 1.0f) v = 1.0f;
                 if (v < -1.0f) v = -1.0f;
                 out[frame * m_player->audioChannels + ch] = v;
+            }
+        }
+        else if (bytesPerSample == 4)
+        {
+            std::vector<int64_t> mix(m_player->audioChannels, 0);
+            for (auto& track : m_player->audioTracks)
+            {
+                if (track->isMuted)
+                    continue;
+
+                while (!track->buffer.empty() &&
+                       track->bufferPts + 1.0 / m_player->audioSampleRate <= samplePts)
+                {
+                    for (int ch = 0; ch < m_player->audioChannels && !track->buffer.empty(); ++ch)
+                        track->buffer.pop_front();
+                    track->bufferPts += 1.0 / m_player->audioSampleRate;
+                }
+
+                if (track->buffer.size() >= static_cast<size_t>(m_player->audioChannels))
+                {
+                    for (int ch = 0; ch < m_player->audioChannels; ++ch)
+                    {
+                        int16_t val = track->buffer.front();
+                        track->buffer.pop_front();
+                        mix[ch] += static_cast<int64_t>(val * track->volume * 65536.0f);
+                    }
+                    track->bufferPts += 1.0 / m_player->audioSampleRate;
+                }
+            }
+            int32_t *out = reinterpret_cast<int32_t*>(outputBuffer);
+            for (int ch = 0; ch < m_player->audioChannels; ++ch)
+            {
+                int64_t v = mix[ch];
+                if (v > INT32_MAX) v = INT32_MAX;
+                if (v < INT32_MIN) v = INT32_MIN;
+                out[frame * m_player->audioChannels + ch] = static_cast<int32_t>(v);
             }
         }
         else

--- a/src/ui_updates.cpp
+++ b/src/ui_updates.cpp
@@ -123,6 +123,8 @@ void UpdateAudioTrackList()
         // Add mute status to the display name
         if (g_videoPlayer->IsAudioTrackMuted(i))
             wTrackName += L" (MUTED)";
+        if (g_videoPlayer->IsAudioTrackVoiceIsolated(i))
+            wTrackName += L" (ISOLATED)";
         
         SendMessage(g_hListBoxAudioTracks, LB_ADDSTRING, 0, (LPARAM)wTrackName.c_str());
     }

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -4,6 +4,7 @@
 #include "video_renderer.h"
 #include "video_cutter.h"
 #include "options_window.h"
+#include "rnnoise.h"
 #include <iostream>
 #include <windows.h>
 #include <windowsx.h>
@@ -376,6 +377,37 @@ void VideoPlayer::SetAudioTrackVolume(int trackIndex, float volume)
         return;
     float clampedVolume = volume < 0.0f ? 0.0f : (volume > 2.0f ? 2.0f : volume);
     audioTracks[trackIndex]->volume = clampedVolume;
+}
+
+bool VideoPlayer::IsAudioTrackVoiceIsolated(int trackIndex) const
+{
+    if (trackIndex < 0 || trackIndex >= static_cast<int>(audioTracks.size()))
+        return false;
+    return audioTracks[trackIndex]->voiceIsolation;
+}
+
+void VideoPlayer::SetAudioTrackVoiceIsolation(int trackIndex, bool enabled)
+{
+    if (trackIndex < 0 || trackIndex >= static_cast<int>(audioTracks.size()))
+        return;
+    auto &track = audioTracks[trackIndex];
+    if (track->voiceIsolation == enabled)
+        return;
+    track->voiceIsolation = enabled;
+    if (enabled)
+    {
+        if (!track->rnnoiseState)
+            track->rnnoiseState = rnnoise_create();
+    }
+    else
+    {
+        if (track->rnnoiseState)
+        {
+            rnnoise_destroy(track->rnnoiseState);
+            track->rnnoiseState = nullptr;
+        }
+        track->rnnoiseBuffer.clear();
+    }
 }
 
 void VideoPlayer::SetMasterVolume(float volume)

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -31,7 +31,7 @@ VideoPlayer::VideoPlayer(HWND parent)
       renderClient(nullptr), audioFormat(nullptr), bufferFrameCount(0),
       audioInitialized(false), audioThreadRunning(false),
       playbackThreadRunning(false),
-      audioSampleRate(44100), audioChannels(2), audioSampleFormat(AV_SAMPLE_FMT_S16),
+      audioSampleRate(48000), audioChannels(2), audioSampleFormat(AV_SAMPLE_FMT_S16),
       originalVideoWndProc(nullptr)
 {
     m_decoder = std::make_unique<VideoDecoder>(this);
@@ -396,8 +396,14 @@ void VideoPlayer::SetAudioTrackVoiceIsolation(int trackIndex, bool enabled)
     track->voiceIsolation = enabled;
     if (enabled)
     {
+        // RNNoise expects 48 kHz, mono, 16-bit audio
+        if (audioSampleRate != 48000 || audioSampleFormat != AV_SAMPLE_FMT_S16)
+        {
+            track->voiceIsolation = false;
+            return;
+        }
         if (!track->rnnoiseState)
-            track->rnnoiseState = rnnoise_create();
+            track->rnnoiseState = rnnoise_create(nullptr);
     }
     else
     {

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -32,6 +32,7 @@ VideoPlayer::VideoPlayer(HWND parent)
       audioInitialized(false), audioThreadRunning(false),
       playbackThreadRunning(false),
       audioSampleRate(48000), audioChannels(2), audioSampleFormat(AV_SAMPLE_FMT_S16),
+      audioIsFloat(false),
       originalVideoWndProc(nullptr)
 {
     m_decoder = std::make_unique<VideoDecoder>(this);

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -138,6 +138,7 @@ public:
     int audioSampleRate;
     int audioChannels;
     AVSampleFormat audioSampleFormat;
+    bool audioIsFloat;
 
     // Shared master clock for A/V synchronization
     std::chrono::high_resolution_clock::time_point masterStartTime;

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -41,6 +41,7 @@ class VideoDecoder;
 class AudioPlayer;
 class VideoRenderer;
 class VideoCutter;
+struct DenoiseState;
 
 // Audio track structure
 struct AudioTrack {
@@ -54,9 +55,13 @@ struct AudioTrack {
     std::deque<int16_t> buffer;
     std::vector<int16_t> resampleBuffer;
     double bufferPts;
+    bool voiceIsolation;
+    DenoiseState *rnnoiseState;
+    std::vector<float> rnnoiseBuffer;
 
     AudioTrack() : streamIndex(-1), codecContext(nullptr), swrContext(nullptr),
-                   frame(nullptr), isMuted(false), volume(1.0f), bufferPts(0.0) {}
+                   frame(nullptr), isMuted(false), volume(1.0f), bufferPts(0.0),
+                   voiceIsolation(false), rnnoiseState(nullptr) {}
 };
 
 class VideoPlayer
@@ -178,6 +183,8 @@ public:
     void SetAudioTrackMuted(int trackIndex, bool muted);
     float GetAudioTrackVolume(int trackIndex) const;
     void SetAudioTrackVolume(int trackIndex, float volume);
+    bool IsAudioTrackVoiceIsolated(int trackIndex) const;
+    void SetAudioTrackVoiceIsolation(int trackIndex, bool enabled);
     void SetMasterVolume(float volume);
     bool CutVideo(const std::wstring& outputFilename, double startTime, double endTime,
                   bool mergeAudio, bool convertH264, bool useNvenc,

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -9,6 +9,10 @@
 #include "upload_dialog.h"
 #include "utils.h"
 
+#include <windowsx.h>
+
+#define ID_TOGGLE_VOICE_ISOLATION 1100
+
 // Forward declarations for functions in other files
 void ApplyDarkTheme(HWND hwnd);
 void RepositionControls(HWND hwnd);
@@ -119,6 +123,18 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         case 1025: // ID_RADIO_USE_SIZE
             UpdateControls();
             break;
+        case ID_TOGGLE_VOICE_ISOLATION:
+        {
+            int sel = (int)SendMessage(g_hListBoxAudioTracks, LB_GETCURSEL, 0, 0);
+            if (sel != LB_ERR && g_videoPlayer)
+            {
+                bool enabled = g_videoPlayer->IsAudioTrackVoiceIsolated(sel);
+                g_videoPlayer->SetAudioTrackVoiceIsolation(sel, !enabled);
+                UpdateAudioTrackList();
+                SendMessage(g_hListBoxAudioTracks, LB_SETCURSEL, sel, 0);
+            }
+            break;
+        }
         }
 
         if ((HWND)lParam == g_hEditStartTime && HIWORD(wParam) == EN_KILLFOCUS)
@@ -178,6 +194,31 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (HIWORD(wParam) == LBN_SELCHANGE && (HWND)lParam == g_hListBoxAudioTracks)
         {
             OnAudioTrackSelectionChanged();
+        }
+        break;
+
+    case WM_CONTEXTMENU:
+        if ((HWND)wParam == g_hListBoxAudioTracks)
+        {
+            POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            if (pt.x == -1 && pt.y == -1)
+            {
+                RECT rc; GetClientRect(g_hListBoxAudioTracks, &rc);
+                pt.x = rc.left; pt.y = rc.top;
+                ClientToScreen(g_hListBoxAudioTracks, &pt);
+            }
+            int sel = (int)SendMessage(g_hListBoxAudioTracks, LB_GETCURSEL, 0, 0);
+            if (sel != LB_ERR && g_videoPlayer)
+            {
+                HMENU menu = CreatePopupMenu();
+                bool enabled = g_videoPlayer->IsAudioTrackVoiceIsolated(sel);
+                AppendMenu(menu, MF_STRING, ID_TOGGLE_VOICE_ISOLATION,
+                           enabled ? L"Disable Voice Isolation" : L"Enable Voice Isolation");
+                TrackPopupMenu(menu, TPM_LEFTALIGN | TPM_TOPALIGN | TPM_RIGHTBUTTON,
+                               pt.x, pt.y, 0, hwnd, nullptr);
+                DestroyMenu(menu);
+            }
+            return 0;
         }
         break;
 


### PR DESCRIPTION
## Summary
- integrate RNNoise library
- add voice isolation toggle for audio tracks via right-click menu
- process isolated tracks in real time during playback

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR, RNNOISE_INCLUDE_DIR, etc. not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cec5c6e4832f83692883a149eca8