### PR TITLE
Separate import/export folders and show video name in title

### DIFF
--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -5,8 +5,10 @@
 #include <commdlg.h>
 #include <thread>
 #include <string>
+#include <filesystem>
 #include "b2_upload.h"
 #include "catbox_upload.h"
+#include "file_handling.h"
 
 // Forward declarations
 void UpdateCutInfoLabel(HWND hwnd);
@@ -74,9 +76,12 @@ void OnCutClicked(HWND hwnd)
     ofn.nFilterIndex = 1;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
     ofn.lpstrDefExt = L"mp4";
+    if (!g_lastSaveDir.empty())
+        ofn.lpstrInitialDir = g_lastSaveDir.c_str();
 
     if (GetSaveFileNameW(&ofn))
     {
+        g_lastSaveDir = std::filesystem::path(szFile).parent_path().wstring();
         SetWindowTextW(g_hStatusText, L"Cutting video... Please wait.");
         EnableWindow(hwnd, FALSE); // Disable UI during cut
 
@@ -175,9 +180,12 @@ void OnExportClicked(HWND hwnd)
     ofn.nFilterIndex = 1;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
     ofn.lpstrDefExt = L"mp4";
+    if (!g_lastSaveDir.empty())
+        ofn.lpstrInitialDir = g_lastSaveDir.c_str();
 
     if (GetSaveFileNameW(&ofn))
     {
+        g_lastSaveDir = std::filesystem::path(szFile).parent_path().wstring();
         SetWindowTextW(g_hStatusText, L"Exporting video... Please wait.");
         EnableWindow(hwnd, FALSE);
 

--- a/src/file_handling.cpp
+++ b/src/file_handling.cpp
@@ -4,6 +4,7 @@
 #include "editing.h"
 #include "options_window.h"
 #include <commdlg.h>
+#include <filesystem>
 
 // Forward declarations
 void UpdateAudioTrackList();
@@ -18,6 +19,10 @@ extern VideoPlayer *g_videoPlayer;
 extern HWND g_hStatusText, g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hLabelTargetSize, g_hRadioUseBitrate, g_hRadioUseSize;
 extern double g_cutStartTime, g_cutEndTime;
 
+// Remember last directories for open and save dialogs
+std::wstring g_lastOpenDir;
+std::wstring g_lastSaveDir;
+
 void OpenVideoFile(HWND hwnd)
 {
     OPENFILENAMEW ofn;
@@ -31,9 +36,12 @@ void OpenVideoFile(HWND hwnd)
     ofn.lpstrFilter = L"Video Files\0*.mp4;*.avi;*.mov;*.mkv;*.wmv;*.flv;*.webm;*.m4v;*.3gp\0All Files\0*.*\0";
     ofn.nFilterIndex = 1;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+    if (!g_lastOpenDir.empty())
+        ofn.lpstrInitialDir = g_lastOpenDir.c_str();
 
     if (GetOpenFileNameW(&ofn))
     {
+        g_lastOpenDir = std::filesystem::path(szFile).parent_path().wstring();
         LoadVideoFile(hwnd, std::wstring(szFile));
     }
 }
@@ -43,6 +51,9 @@ void LoadVideoFile(HWND hwnd, const std::wstring& filename)
     if (g_videoPlayer && g_videoPlayer->LoadVideo(filename))
     {
         SetWindowTextW(g_hStatusText, (L"Loaded: " + filename).c_str());
+        g_lastOpenDir = std::filesystem::path(filename).parent_path().wstring();
+        std::wstring title = L"Video Editor - " + std::filesystem::path(filename).filename().wstring();
+        SetWindowTextW(hwnd, title.c_str());
         EnableWindow(g_hButtonPlay, TRUE);
         EnableWindow(g_hButtonPause, TRUE);
         EnableWindow(g_hButtonStop, TRUE);

--- a/src/file_handling.h
+++ b/src/file_handling.h
@@ -5,3 +5,6 @@
 
 void OpenVideoFile(HWND hwnd);
 void LoadVideoFile(HWND hwnd, const std::wstring& filename);
+
+extern std::wstring g_lastOpenDir;
+extern std::wstring g_lastSaveDir;


### PR DESCRIPTION
## Summary
- Keep import and export dialogs independent by tracking last used directories separately
- Update main window title to include the name of the loaded video

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR, AVCODEC_LIBRARY, AVFORMAT_LIBRARY, AVUTIL_LIBRARY, RNNOISE_LIBRARY, SWRESAMPLE_LIBRARY, SWSCALE_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace938f980832fa2c35eb9d11e434f