### PR TITLE
Ensure comma and period keys step one frame

### DIFF
--- a/src/video_decoder.cpp
+++ b/src/video_decoder.cpp
@@ -187,13 +187,8 @@ bool VideoDecoder::DecodeNextFrame(bool updateDisplay) {
                 if (updateDisplay)
                 {
                     m_player->m_renderer->UpdateDisplay();
+                    UpdateTimeline();
                 }
-                else
-                {
-                    InvalidateRect(m_player->videoWindow, nullptr, FALSE);
-                }
-
-                UpdateTimeline();
 
                 return true;
             }

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -263,10 +263,14 @@ void VideoPlayer::SeekToFrame(int64_t frameNumber)
         return;
 
     double seconds = frameRate > 0 ? (frameNumber / frameRate) : 0.0;
-    SeekToTime(seconds);
+    // Seek without decoding extra frames so we can step precisely
+    SeekToTime(seconds, 0);
+    // Adjust currentFrame so DecodeNextFrame sets it to the requested frame
+    currentFrame = frameNumber - 1;
+    m_decoder->DecodeNextFrame(true);
 }
 
-void VideoPlayer::SeekToTime(double seconds)
+void VideoPlayer::SeekToTime(double seconds, int decodeCount)
 {
     if (!isLoaded)
         return;
@@ -298,8 +302,8 @@ void VideoPlayer::SeekToTime(double seconds)
         currentPts = seconds;
     }
 
-    // Decode a few frames after seeking so the display updates immediately
-    for (int i = 0; i < 3; ++i)
+    // Decode frames after seeking so the display updates immediately
+    for (int i = 0; i < decodeCount; ++i)
     {
         if (!m_decoder->DecodeNextFrame(true))
             break;

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -282,8 +282,16 @@ void VideoPlayer::SeekToFrame(int64_t frameNumber)
     // Decode frames until we reach the requested frame
     while (currentFrame < frameNumber)
     {
-        if (!m_decoder->DecodeNextFrame(true))
+        bool showFrame = (currentFrame + 1 == frameNumber);
+        if (!m_decoder->DecodeNextFrame(showFrame))
             break;
+    }
+
+    // Discard any audio decoded during stepping
+    {
+        std::lock_guard<std::mutex> lock(audioMutex);
+        for (auto& tr : audioTracks)
+            tr->buffer.clear();
     }
 }
 

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -262,12 +262,29 @@ void VideoPlayer::SeekToFrame(int64_t frameNumber)
     if (!isLoaded || frameNumber < 0 || frameNumber >= totalFrames)
         return;
 
+    if (frameNumber == currentFrame)
+        return;
+
+    // If stepping forward one frame, avoid seeking and just decode the next frame
+    if (frameNumber == currentFrame + 1)
+    {
+        m_decoder->DecodeNextFrame(true);
+        return;
+    }
+
+    // For all other cases (stepping backward or jumping), seek based on time
     double seconds = frameRate > 0 ? (frameNumber / frameRate) : 0.0;
-    // Seek without decoding extra frames so we can step precisely
     SeekToTime(seconds, 0);
-    // Adjust currentFrame so DecodeNextFrame sets it to the requested frame
+
+    // Adjust currentFrame so the next decoded frame becomes the requested one
     currentFrame = frameNumber - 1;
-    m_decoder->DecodeNextFrame(true);
+
+    // Decode frames until we reach the requested frame
+    while (currentFrame < frameNumber)
+    {
+        if (!m_decoder->DecodeNextFrame(true))
+            break;
+    }
 }
 
 void VideoPlayer::SeekToTime(double seconds, int decodeCount)

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -276,8 +276,8 @@ void VideoPlayer::SeekToFrame(int64_t frameNumber)
     double seconds = frameRate > 0 ? (frameNumber / frameRate) : 0.0;
     SeekToTime(seconds, 0);
 
-    // Adjust currentFrame so the next decoded frame becomes the requested one
-    currentFrame = frameNumber - 1;
+    // Ensure the next decoded frame is processed
+    currentFrame--;
 
     // Decode frames until we reach the requested frame
     while (currentFrame < frameNumber)
@@ -315,8 +315,20 @@ void VideoPlayer::SeekToTime(double seconds, int decodeCount)
                 tr->buffer.clear();
         }
 
-        currentFrame = (int64_t)(seconds * frameRate);
-        currentPts = seconds;
+        // Estimate the frame and PTS we landed on using the stream index
+        int idx = av_index_search_timestamp(vs, ts, AVSEEK_FLAG_BACKWARD);
+        if (idx >= 0 && vs->index_entries)
+        {
+            int64_t keyTs = vs->index_entries[idx].timestamp;
+            double keyTime = keyTs * av_q2d(vs->time_base) - startTimeOffset;
+            currentPts = keyTime;
+            currentFrame = (int64_t)(currentPts * frameRate);
+        }
+        else
+        {
+            currentPts = seconds;
+            currentFrame = (int64_t)(seconds * frameRate);
+        }
     }
 
     // Decode frames after seeking so the display updates immediately

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -316,10 +316,11 @@ void VideoPlayer::SeekToTime(double seconds, int decodeCount)
         }
 
         // Estimate the frame and PTS we landed on using the stream index
-        int idx = av_index_search_timestamp(vs, ts, AVSEEK_FLAG_BACKWARD);
-        if (idx >= 0 && vs->index_entries)
+        const AVIndexEntry *entry =
+            avformat_index_get_entry_from_timestamp(vs, ts, AVSEEK_FLAG_BACKWARD);
+        if (entry)
         {
-            int64_t keyTs = vs->index_entries[idx].timestamp;
+            int64_t keyTs = entry->timestamp;
             double keyTime = keyTs * av_q2d(vs->time_base) - startTimeOffset;
             currentPts = keyTime;
             currentFrame = (int64_t)(currentPts * frameRate);

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -272,7 +272,29 @@ void VideoPlayer::SeekToFrame(int64_t frameNumber)
         return;
     }
 
-    // For all other cases (stepping backward or jumping), seek based on time
+    // If stepping backward one frame, base the seek on the current timestamp
+    if (frameNumber == currentFrame - 1)
+    {
+        double seconds = currentPts - (frameRate > 0 ? (1.0 / frameRate) : 0.0);
+        if (seconds < 0.0)
+            seconds = 0.0;
+        SeekToTime(seconds, 0);
+        currentFrame--;
+        while (currentFrame < frameNumber)
+        {
+            bool showFrame = (currentFrame + 1 == frameNumber);
+            if (!m_decoder->DecodeNextFrame(showFrame))
+                break;
+        }
+        {
+            std::lock_guard<std::mutex> lock(audioMutex);
+            for (auto& tr : audioTracks)
+                tr->buffer.clear();
+        }
+        return;
+    }
+
+    // For all other cases (jumping), seek based on frame number
     double seconds = frameRate > 0 ? (frameNumber / frameRate) : 0.0;
     SeekToTime(seconds, 0);
 

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -175,7 +175,7 @@ public:
     bool IsLoaded() const { return isLoaded; }
 
     void SeekToFrame(int64_t frameNumber);
-    void SeekToTime(double seconds);
+    void SeekToTime(double seconds, int decodeCount = 3);
 
     double GetDuration() const;
     double GetCurrentTime() const;


### PR DESCRIPTION
## Summary
- Avoid decoding extra frames when seeking so stepping uses precise frame counts
- Allow `SeekToTime` to control how many frames are decoded after seeking

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR and libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf2dd2be4832f9a60ee768903e198