### PR TITLE
Remove frame history and rely on seek-based frame navigation

### DIFF
--- a/src/video_decoder.cpp
+++ b/src/video_decoder.cpp
@@ -178,38 +178,7 @@ bool VideoDecoder::DecodeNextFrame(bool updateDisplay) {
                     0, m_player->frameHeight,
                     m_player->frameRGB->data, m_player->frameRGB->linesize);
 
-                // Record frame into history for exact back/forward stepping
-                {
-                    int rgbBytes = av_image_get_buffer_size(AV_PIX_FMT_BGRA, m_player->frameWidth, m_player->frameHeight, 32);
-                    if (rgbBytes < 0) rgbBytes = m_player->frameWidth * m_player->frameHeight * 4;
-                    // Avoid pushing exact duplicate PTS consecutively
-                    bool push = true;
-                    if (!m_player->frameHistory.empty())
-                    {
-                        if (std::abs(m_player->frameHistory.back().pts - m_player->currentPts) < 1e-9)
-                            push = false;
-                    }
-                    if (push)
-                    {
-                        VideoPlayer::FrameHistoryEntry entry;
-                        entry.rgb.resize(rgbBytes);
-                        std::memcpy(entry.rgb.data(), m_player->buffer, rgbBytes);
-                        entry.pts = m_player->currentPts;
-                        entry.frameIndex = m_player->currentFrame;
-
-                        // When we decode a new frame, discard any "redo" portion (if user rewound and then continued)
-                        if (m_player->historyDisplayIndex >= 0 && (size_t)m_player->historyDisplayIndex + 1 < m_player->frameHistory.size())
-                        {
-                            m_player->frameHistory.erase(m_player->frameHistory.begin() + m_player->historyDisplayIndex + 1, m_player->frameHistory.end());
-                        }
-                        m_player->frameHistory.push_back(std::move(entry));
-                        // Trim to max
-                        while (m_player->frameHistory.size() > m_player->maxHistoryFrames)
-                            m_player->frameHistory.pop_front();
-                        // Point display to the newest
-                        m_player->historyDisplayIndex = (int)m_player->frameHistory.size() - 1;
-                    }
-                }
+                // No frame history: frame data is already in m_player->buffer for display
 
                 av_frame_unref(m_player->hwFrame);
                 if (swFrame != m_player->hwFrame)

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -87,8 +87,6 @@ bool VideoPlayer::LoadVideo(const std::wstring &filename)
 {
     UnloadVideo();
     loadedFilename = filename;
-    frameHistory.clear();
-    historyDisplayIndex = -1;
 
     int bufSize = WideCharToMultiByte(CP_UTF8, 0, filename.c_str(), -1, nullptr, 0, nullptr, nullptr);
     std::string utf8Filename(bufSize, 0);
@@ -241,8 +239,6 @@ void VideoPlayer::Stop()
     Pause();
     currentFrame = 0;
     currentPts = 0.0;
-    frameHistory.clear();
-    historyDisplayIndex = -1;
     if (isLoaded)
     {
         av_seek_frame(formatContext, videoStreamIndex, 0, AVSEEK_FLAG_FRAME);
@@ -270,61 +266,22 @@ void VideoPlayer::SeekToFrame(int64_t frameNumber)
     if (frameNumber == currentFrame)
         return;
 
-    // If stepping forward one frame, use history if available, else decode next
+    // Optimize stepping forward one frame by decoding without seeking
     if (frameNumber == currentFrame + 1)
     {
-        if (historyDisplayIndex >= 0 && (size_t)historyDisplayIndex + 1 < frameHistory.size())
-        {
-            // Move forward within history
-            historyDisplayIndex++;
-            const auto &entry = frameHistory[historyDisplayIndex];
-            std::memcpy(buffer, entry.rgb.data(), entry.rgb.size());
-            currentPts = entry.pts;
-            currentFrame = entry.frameIndex;
-            m_renderer->UpdateDisplay();
-        }
-        else
-        {
-            // Decode to extend history
-            m_decoder->DecodeNextFrame(true);
-        }
+        m_decoder->DecodeNextFrame(true);
         return;
     }
 
-    // If stepping backward one frame, prefer history for exactness
-    if (frameNumber == currentFrame - 1)
-    {
-        if (historyDisplayIndex > 0 && (size_t)historyDisplayIndex <= frameHistory.size())
-        {
-            historyDisplayIndex--;
-            const auto &entry = frameHistory[historyDisplayIndex];
-            std::memcpy(buffer, entry.rgb.data(), entry.rgb.size());
-            currentPts = entry.pts;
-            currentFrame = entry.frameIndex;
-            m_renderer->UpdateDisplay();
-            return;
-        }
-        // Fall back: if no history, do a minimal seek+decode
-        double seconds = frameRate > 0 ? ((frameNumber) / frameRate) : 0.0;
-        SeekToTime(seconds, 1);
-        return;
-    }
-
-    // For all other cases (larger jumps), use normal seeking
+    // For any other frame (including stepping backward), perform a seek
     double seconds = frameRate > 0 ? (frameNumber / frameRate) : 0.0;
     SeekToTime(seconds, 0);
 
-    // Simple approach: if we're not at the exact frame, decode a few more
-    if (currentFrame < frameNumber)
+    // Decode frames until the requested frame is reached
+    while (currentFrame < frameNumber)
     {
-        int framesToDecode = std::min(5, (int)(frameNumber - currentFrame));
-        for (int i = 0; i < framesToDecode; i++)
-        {
-            if (!m_decoder->DecodeNextFrame(true))
-                break;
-            if (currentFrame >= frameNumber)
-                break;
-        }
+        if (!m_decoder->DecodeNextFrame(true))
+            break;
     }
 }
 
@@ -371,9 +328,6 @@ void VideoPlayer::SeekToTime(double seconds, int decodeCount)
             currentPts = seconds;
             currentFrame = (int64_t)(seconds * frameRate);
         }
-    // Seeking invalidates frame history relative to display
-    frameHistory.clear();
-    historyDisplayIndex = -1;
     }
 
     // Decode frames after seeking so the display updates immediately

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -163,18 +163,6 @@ public:
 private:
     // When true, audio packets are dropped while stepping to avoid stalls
     bool dropAudioDuringStepping;
-    // Temporary pixel buffer to restore the last frame during precise backward stepping
-    std::vector<uint8_t> stepBackupBuffer;
-
-    // Frame history for precise single-frame navigation without seeking
-    struct FrameHistoryEntry {
-        std::vector<uint8_t> rgb; // BGRA bytes of the frameRGB at decode time
-        double pts{0.0};
-        int64_t frameIndex{0};
-    };
-    std::deque<FrameHistoryEntry> frameHistory; // ordered oldest -> newest
-    int historyDisplayIndex{-1}; // -1 when empty; else 0..size-1 points to current displayed frame in history
-    size_t maxHistoryFrames{16}; // keep last N frames; tune for memory/precision
 
 public:
     VideoPlayer(HWND parent);


### PR DESCRIPTION
## Summary
- Replace frame-history based stepping with seek-based logic so backward stepping works across entire video.
- Simplify decoder by dropping frame history bookkeeping.

## Testing
- `cmake ..` *(fails: FFMPEG_INCLUDE_DIR, AV* libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0a5508c0832f8bd73164743811db