### PR TITLE
Add clip preview playback button

### DIFF
--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -55,6 +55,17 @@ void OnSetEndClicked(HWND hwnd)
     UpdateCutTimeEdits();
 }
 
+void OnPlayClipClicked(HWND hwnd)
+{
+    if (!g_videoPlayer || g_cutStartTime < 0 || g_cutEndTime <= g_cutStartTime)
+    {
+        MessageBoxW(hwnd, L"Please set valid start and end points for the clip.", L"Error", MB_OK | MB_ICONERROR);
+        return;
+    }
+    g_videoPlayer->PlayClip(g_cutStartTime, g_cutEndTime);
+    UpdateControls();
+}
+
 void OnCutClicked(HWND hwnd)
 {
     g_lastOperationWasExport = false;

--- a/src/editing.cpp
+++ b/src/editing.cpp
@@ -66,6 +66,24 @@ void OnPlayClipClicked(HWND hwnd)
     UpdateControls();
 }
 
+void OnPlayEndClipClicked(HWND hwnd)
+{
+    if (!g_videoPlayer || g_cutStartTime < 0 || g_cutEndTime <= g_cutStartTime)
+    {
+        MessageBoxW(hwnd, L"Please set valid start and end points for the clip.", L"Error", MB_OK | MB_ICONERROR);
+        return;
+    }
+
+    double previewStart = g_cutEndTime - 3.0;
+    if (previewStart < g_cutStartTime)
+        previewStart = g_cutStartTime;
+    if (previewStart < 0)
+        previewStart = 0;
+
+    g_videoPlayer->PlayClip(previewStart, g_cutEndTime);
+    UpdateControls();
+}
+
 void OnCutClicked(HWND hwnd)
 {
     g_lastOperationWasExport = false;

--- a/src/editing.h
+++ b/src/editing.h
@@ -6,6 +6,7 @@
 void OnSetStartClicked(HWND hwnd);
 void OnSetEndClicked(HWND hwnd);
 void OnPlayClipClicked(HWND hwnd);
+void OnPlayEndClipClicked(HWND hwnd);
 void OnCutClicked(HWND hwnd);
 void OnExportClicked(HWND hwnd);
 

--- a/src/editing.h
+++ b/src/editing.h
@@ -5,6 +5,7 @@
 
 void OnSetStartClicked(HWND hwnd);
 void OnSetEndClicked(HWND hwnd);
+void OnPlayClipClicked(HWND hwnd);
 void OnCutClicked(HWND hwnd);
 void OnExportClicked(HWND hwnd);
 

--- a/src/file_handling.cpp
+++ b/src/file_handling.cpp
@@ -16,7 +16,7 @@ void UpdateTimeline();
 
 // Global variables
 extern VideoPlayer *g_videoPlayer;
-extern HWND g_hStatusText, g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hLabelTargetSize, g_hRadioUseBitrate, g_hRadioUseSize;
+extern HWND g_hStatusText, g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonPlayEnd, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hLabelTargetSize, g_hRadioUseBitrate, g_hRadioUseSize;
 extern double g_cutStartTime, g_cutEndTime;
 
 // Remember last directories for open and save dialogs

--- a/src/file_handling.cpp
+++ b/src/file_handling.cpp
@@ -16,7 +16,7 @@ void UpdateTimeline();
 
 // Global variables
 extern VideoPlayer *g_videoPlayer;
-extern HWND g_hStatusText, g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hLabelTargetSize, g_hRadioUseBitrate, g_hRadioUseSize;
+extern HWND g_hStatusText, g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hLabelTargetSize, g_hRadioUseBitrate, g_hRadioUseSize;
 extern double g_cutStartTime, g_cutEndTime;
 
 // Remember last directories for open and save dialogs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ HWND g_hRadioUseBitrate, g_hRadioUseSize;
 HWND g_hLabelBitrate;
 HWND g_hEditTargetSize;
 HWND g_hLabelTargetSize;
-HWND g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip;
+HWND g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonPlayEnd;
 HWND g_hLabelCutInfo;
 HWND g_hButtonOptions;
 double g_cutStartTime = -1.0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ HWND g_hRadioUseBitrate, g_hRadioUseSize;
 HWND g_hLabelBitrate;
 HWND g_hEditTargetSize;
 HWND g_hLabelTargetSize;
-HWND g_hEditStartTime, g_hEditEndTime;
+HWND g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip;
 HWND g_hLabelCutInfo;
 HWND g_hButtonOptions;
 double g_cutStartTime = -1.0;

--- a/src/timeline.cpp
+++ b/src/timeline.cpp
@@ -44,6 +44,20 @@ LRESULT CALLBACK TimelineProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             }
             else
             {
+                if (g_videoPlayer->IsClipPreviewActive())
+                {
+                    if (seekTime < g_cutStartTime || seekTime > g_cutEndTime)
+                    {
+                        g_videoPlayer->CancelClipPreview();
+                    }
+                    else
+                    {
+                        g_videoPlayer->SeekToTime(seekTime);
+                        InvalidateRect(hwnd, NULL, FALSE);
+                        UpdateControls();
+                        return 0;
+                    }
+                }
                 g_timelineDragMode = DragMode::Cursor;
                 g_wasPlayingBeforeDrag = g_videoPlayer->IsPlaying();
                 if (g_wasPlayingBeforeDrag)

--- a/src/ui_controls.cpp
+++ b/src/ui_controls.cpp
@@ -32,6 +32,7 @@ void ApplyDarkTheme(HWND hwnd);
 #define ID_RADIO_USE_BITRATE 1024
 #define ID_RADIO_USE_SIZE 1025
 #define ID_CONTEXT_VOICE_ISOLATION 1026
+#define ID_BUTTON_PLAY_CLIP 1027
 
 // Global variables
 extern VideoPlayer *g_videoPlayer;
@@ -45,7 +46,7 @@ extern HWND g_hButtonSetStart, g_hButtonSetEnd, g_hButtonCut, g_hCheckboxMergeAu
 extern HWND g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize;
 extern HWND g_hRadioUseBitrate, g_hRadioUseSize;
 extern HWND g_hLabelBitrate, g_hLabelTargetSize;
-extern HWND g_hEditStartTime, g_hEditEndTime;
+extern HWND g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip;
 extern HWND g_hLabelCutInfo;
 extern HWND g_hButtonOptions;
 
@@ -223,6 +224,14 @@ void CreateControls(HWND hwnd)
         (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(g_hEditEndTime);
 
+    g_hButtonPlayClip = CreateWindow(
+        L"BUTTON", L"\x25B6",
+        WS_VISIBLE | WS_CHILD | BS_PUSHBUTTON,
+        550, 405, 30, 20,
+        hwnd, (HMENU)ID_BUTTON_PLAY_CLIP,
+        (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(g_hButtonPlayClip);
+
     g_hLabelCutInfo = CreateWindow(
         L"STATIC", L"Cut points not set.",
         WS_VISIBLE | WS_CHILD | SS_LEFT,
@@ -328,6 +337,7 @@ void CreateControls(HWND hwnd)
     EnableWindow(g_hButtonSetEnd, FALSE);
     EnableWindow(g_hEditStartTime, FALSE);
     EnableWindow(g_hEditEndTime, FALSE);
+    EnableWindow(g_hButtonPlayClip, FALSE);
     EnableWindow(g_hButtonCut, FALSE);
     EnableWindow(g_hCheckboxMergeAudio, FALSE);
     EnableWindow(g_hRadioCopyCodec, FALSE);
@@ -385,6 +395,7 @@ void RepositionControls(HWND hwnd)
     MoveWindow(g_hButtonSetEnd, audioControlsX + 105, editingControlsY + 25, 95, 25, TRUE);
     MoveWindow(g_hEditStartTime, audioControlsX, editingControlsY + 55, 95, 20, TRUE);
     MoveWindow(g_hEditEndTime, audioControlsX + 105, editingControlsY + 55, 95, 20, TRUE);
+    MoveWindow(g_hButtonPlayClip, audioControlsX + 200, editingControlsY + 55, 20, 20, TRUE);
     MoveWindow(g_hLabelCutInfo, audioControlsX, editingControlsY + 80, 200, 40, TRUE);
     MoveWindow(g_hButtonCut, audioControlsX, editingControlsY + 125, 200, 30, TRUE);
     MoveWindow(g_hCheckboxMergeAudio, audioControlsX, editingControlsY + 160, 200, 25, TRUE);

--- a/src/ui_controls.cpp
+++ b/src/ui_controls.cpp
@@ -33,6 +33,7 @@ void ApplyDarkTheme(HWND hwnd);
 #define ID_RADIO_USE_SIZE 1025
 #define ID_CONTEXT_VOICE_ISOLATION 1026
 #define ID_BUTTON_PLAY_CLIP 1027
+#define ID_BUTTON_PLAY_END 1028
 
 // Global variables
 extern VideoPlayer *g_videoPlayer;
@@ -46,7 +47,7 @@ extern HWND g_hButtonSetStart, g_hButtonSetEnd, g_hButtonCut, g_hCheckboxMergeAu
 extern HWND g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize;
 extern HWND g_hRadioUseBitrate, g_hRadioUseSize;
 extern HWND g_hLabelBitrate, g_hLabelTargetSize;
-extern HWND g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip;
+extern HWND g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonPlayEnd;
 extern HWND g_hLabelCutInfo;
 extern HWND g_hButtonOptions;
 
@@ -232,6 +233,14 @@ void CreateControls(HWND hwnd)
         (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE), nullptr);
     ApplyDarkTheme(g_hButtonPlayClip);
 
+    g_hButtonPlayEnd = CreateWindow(
+        L"BUTTON", L"\x25B6",
+        WS_VISIBLE | WS_CHILD | BS_PUSHBUTTON,
+        585, 405, 30, 20,
+        hwnd, (HMENU)ID_BUTTON_PLAY_END,
+        (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE), nullptr);
+    ApplyDarkTheme(g_hButtonPlayEnd);
+
     g_hLabelCutInfo = CreateWindow(
         L"STATIC", L"Cut points not set.",
         WS_VISIBLE | WS_CHILD | SS_LEFT,
@@ -338,6 +347,7 @@ void CreateControls(HWND hwnd)
     EnableWindow(g_hEditStartTime, FALSE);
     EnableWindow(g_hEditEndTime, FALSE);
     EnableWindow(g_hButtonPlayClip, FALSE);
+    EnableWindow(g_hButtonPlayEnd, FALSE);
     EnableWindow(g_hButtonCut, FALSE);
     EnableWindow(g_hCheckboxMergeAudio, FALSE);
     EnableWindow(g_hRadioCopyCodec, FALSE);
@@ -374,7 +384,7 @@ void RepositionControls(HWND hwnd)
     MoveWindow(g_hButtonOptions, optionsX, mainControlsY, optionsWidth, mainControlsHeight, TRUE);
 
     // Audio controls (aligned to the right)
-    int audioControlsWidth = 220;
+    int audioControlsWidth = 250;
     int audioControlsX = clientRect.right - audioControlsWidth - 10;
     int audioControlsY = 50;
 
@@ -396,6 +406,7 @@ void RepositionControls(HWND hwnd)
     MoveWindow(g_hEditStartTime, audioControlsX, editingControlsY + 55, 95, 20, TRUE);
     MoveWindow(g_hEditEndTime, audioControlsX + 105, editingControlsY + 55, 95, 20, TRUE);
     MoveWindow(g_hButtonPlayClip, audioControlsX + 200, editingControlsY + 55, 20, 20, TRUE);
+    MoveWindow(g_hButtonPlayEnd, audioControlsX + 225, editingControlsY + 55, 20, 20, TRUE);
     MoveWindow(g_hLabelCutInfo, audioControlsX, editingControlsY + 80, 200, 40, TRUE);
     MoveWindow(g_hButtonCut, audioControlsX, editingControlsY + 125, 200, 30, TRUE);
     MoveWindow(g_hCheckboxMergeAudio, audioControlsX, editingControlsY + 160, 200, 25, TRUE);

--- a/src/ui_updates.cpp
+++ b/src/ui_updates.cpp
@@ -9,7 +9,7 @@ std::wstring FormatTime(double totalSeconds, bool showMilliseconds);
 
 // Global variables
 extern VideoPlayer *g_videoPlayer;
-extern HWND g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hStatusText, g_hLabelCutInfo, g_hRadioUseBitrate, g_hRadioUseSize, g_hLabelBitrate, g_hLabelTargetSize;
+extern HWND g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonPlayEnd, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hStatusText, g_hLabelCutInfo, g_hRadioUseBitrate, g_hRadioUseSize, g_hLabelBitrate, g_hLabelTargetSize;
 extern double g_cutStartTime, g_cutEndTime;
 
 void UpdateControls()
@@ -48,7 +48,8 @@ void UpdateControls()
         SetWindowTextW(g_hButtonCut, L"Cut Video");
         EnableWindow(g_hButtonCut, isLoaded && hasStart && hasEnd && g_cutEndTime > g_cutStartTime);
     }
-    EnableWindow(g_hButtonPlayClip, isLoaded && !isPlaying && hasStart && hasEnd && g_cutEndTime > g_cutStartTime);
+    EnableWindow(g_hButtonPlayClip, isLoaded && hasStart && hasEnd && g_cutEndTime > g_cutStartTime);
+    EnableWindow(g_hButtonPlayEnd, isLoaded && hasStart && hasEnd && g_cutEndTime > g_cutStartTime);
 
    bool canMerge = g_videoPlayer && g_videoPlayer->GetAudioTrackCount() > 1;
    EnableWindow(g_hCheckboxMergeAudio, isLoaded && canMerge);

--- a/src/ui_updates.cpp
+++ b/src/ui_updates.cpp
@@ -9,7 +9,7 @@ std::wstring FormatTime(double totalSeconds, bool showMilliseconds);
 
 // Global variables
 extern VideoPlayer *g_videoPlayer;
-extern HWND g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hStatusText, g_hLabelCutInfo, g_hRadioUseBitrate, g_hRadioUseSize, g_hLabelBitrate, g_hLabelTargetSize;
+extern HWND g_hButtonPlay, g_hButtonPause, g_hButtonStop, g_hTimeline, g_hListBoxAudioTracks, g_hButtonMuteTrack, g_hSliderTrackVolume, g_hSliderMasterVolume, g_hButtonSetStart, g_hButtonSetEnd, g_hEditStartTime, g_hEditEndTime, g_hButtonPlayClip, g_hButtonCut, g_hCheckboxMergeAudio, g_hRadioCopyCodec, g_hRadioH264, g_hEditBitrate, g_hEditTargetSize, g_hStatusText, g_hLabelCutInfo, g_hRadioUseBitrate, g_hRadioUseSize, g_hLabelBitrate, g_hLabelTargetSize;
 extern double g_cutStartTime, g_cutEndTime;
 
 void UpdateControls()
@@ -48,6 +48,7 @@ void UpdateControls()
         SetWindowTextW(g_hButtonCut, L"Cut Video");
         EnableWindow(g_hButtonCut, isLoaded && hasStart && hasEnd && g_cutEndTime > g_cutStartTime);
     }
+    EnableWindow(g_hButtonPlayClip, isLoaded && !isPlaying && hasStart && hasEnd && g_cutEndTime > g_cutStartTime);
 
    bool canMerge = g_videoPlayer && g_videoPlayer->GetAudioTrackCount() > 1;
    EnableWindow(g_hCheckboxMergeAudio, isLoaded && canMerge);

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -267,6 +267,9 @@ void VideoPlayer::PlayClip(double startTime, double endTime)
 {
     if (!isLoaded)
         return;
+    if (isPlaying)
+        Pause();
+
     clipPreviewEndTime = endTime;
     clipPreviewActive = true;
     SeekToTime(startTime);

--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -24,6 +24,7 @@ VideoPlayer::VideoPlayer(HWND parent)
       buffer(nullptr), rgbBufferSize(0), videoStreamIndex(-1), frameWidth(0), frameHeight(0),
       isLoaded(false), isPlaying(false), frameRate(0), currentFrame(0),
       totalFrames(0), currentPts(0.0), duration(0.0), startTimeOffset(0.0),
+      clipPreviewActive(false), clipPreviewEndTime(0.0),
       cropRect{0,0,0,0}, hasCrop(false), selectingCrop(false), cropStart{0,0}, cropCurrent{0,0},
       videoWindow(nullptr),
       d2dFactory(nullptr), d2dRenderTarget(nullptr), d2dBitmap(nullptr), playbackTimer(0),
@@ -219,7 +220,8 @@ void VideoPlayer::Pause()
     if (isPlaying)
     {
         isPlaying = false;
-        
+        clipPreviewActive = false;
+
         m_audioPlayer->StopThread();
         
         if (playbackThreadRunning)
@@ -238,6 +240,7 @@ void VideoPlayer::Pause()
 
 void VideoPlayer::Stop()
 {
+    clipPreviewActive = false;
     Pause();
     currentFrame = 0;
     currentPts = 0.0;
@@ -257,6 +260,29 @@ void VideoPlayer::Stop()
         std::lock_guard<std::mutex> lock(audioMutex);
         for (auto& tr : audioTracks)
             tr->buffer.clear();
+    }
+}
+
+void VideoPlayer::PlayClip(double startTime, double endTime)
+{
+    if (!isLoaded)
+        return;
+    clipPreviewEndTime = endTime;
+    clipPreviewActive = true;
+    SeekToTime(startTime);
+    Play();
+}
+
+void VideoPlayer::CancelClipPreview()
+{
+    if (clipPreviewActive)
+    {
+        clipPreviewActive = false;
+        if (isPlaying)
+        {
+            Pause();
+            UpdateControls();
+        }
     }
 }
 
@@ -499,7 +525,15 @@ void CALLBACK VideoPlayer::TimerProc(HWND hwnd, UINT, UINT_PTR, DWORD)
 void VideoPlayer::OnTimer()
 {
     if (isPlaying)
+    {
         m_decoder->DecodeNextFrame(true);
+        if (clipPreviewActive && currentPts >= clipPreviewEndTime)
+        {
+            clipPreviewActive = false;
+            Pause();
+            UpdateControls();
+        }
+    }
 }
 
 // Audio track management methods
@@ -667,6 +701,14 @@ void VideoPlayer::PlaybackThreadFunction()
     {
         if (!m_decoder->DecodeNextFrame(false, true))
             break;
+
+        if (clipPreviewActive && currentPts >= clipPreviewEndTime)
+        {
+            clipPreviewActive = false;
+            Pause();
+            UpdateControls();
+            break;
+        }
 
         double target = currentPts - startPts;
         double elapsed = std::chrono::duration<double>(std::chrono::high_resolution_clock::now() - startTime).count();

--- a/src/video_player.h
+++ b/src/video_player.h
@@ -103,6 +103,8 @@ public:
     double currentPts;
     double duration;
     double startTimeOffset;
+    bool clipPreviewActive;
+    double clipPreviewEndTime;
 
     // Crop selection
     RECT cropRect;
@@ -182,6 +184,9 @@ public:
     bool Play();
     void Pause();
     void Stop();
+    void PlayClip(double startTime, double endTime);
+    void CancelClipPreview();
+    bool IsClipPreviewActive() const { return clipPreviewActive; }
     bool IsPlaying() const { return isPlaying; }
     bool IsLoaded() const { return isLoaded; }
 

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -24,6 +24,7 @@ void OnSetStartClicked(HWND hwnd);
 void OnSetEndClicked(HWND hwnd);
 void OnCutClicked(HWND hwnd);
 void OnExportClicked(HWND hwnd);
+void OnPlayClipClicked(HWND hwnd);
 void OnAudioTrackSelectionChanged();
 void UpdateAudioTrackList();
 double ParseTimeString(const std::wstring& str);
@@ -108,6 +109,9 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         case 1012: // ID_BUTTON_SET_END
             OnSetEndClicked(hwnd);
+            break;
+        case 1027: // ID_BUTTON_PLAY_CLIP
+            OnPlayClipClicked(hwnd);
             break;
         case 1013: // ID_BUTTON_CUT
             if (g_cutStartTime < 0 && g_cutEndTime < 0)

--- a/src/window_proc.cpp
+++ b/src/window_proc.cpp
@@ -25,6 +25,7 @@ void OnSetEndClicked(HWND hwnd);
 void OnCutClicked(HWND hwnd);
 void OnExportClicked(HWND hwnd);
 void OnPlayClipClicked(HWND hwnd);
+void OnPlayEndClipClicked(HWND hwnd);
 void OnAudioTrackSelectionChanged();
 void UpdateAudioTrackList();
 double ParseTimeString(const std::wstring& str);
@@ -112,6 +113,9 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         case 1027: // ID_BUTTON_PLAY_CLIP
             OnPlayClipClicked(hwnd);
+            break;
+        case 1028: // ID_BUTTON_PLAY_END_CLIP
+            OnPlayEndClipClicked(hwnd);
             break;
         case 1013: // ID_BUTTON_CUT
             if (g_cutStartTime < 0 && g_cutEndTime < 0)


### PR DESCRIPTION
## Summary
- add Play Clip button next to timestamp inputs to preview cuts
- implement VideoPlayer range playback and auto-stop at clip end
- stop clip preview when timeline seeks outside the selected range

## Testing
- `cmake ..` *(fails: FFMPEG_INCLUDE_DIR not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae833f8d74832fa6cdad77728817c5