### PR TITLE
Fix residual frame when loading smaller resolution video

### DIFF
--- a/src/video_player.cpp
+++ b/src/video_player.cpp
@@ -183,6 +183,17 @@ void VideoPlayer::UnloadVideo()
     Stop();
     m_audioPlayer->CleanupTracks();
     m_decoder->Cleanup();
+    if (d2dBitmap)
+    {
+        d2dBitmap->Release();
+        d2dBitmap = nullptr;
+    }
+    if (d2dRenderTarget)
+    {
+        d2dRenderTarget->BeginDraw();
+        d2dRenderTarget->Clear(D2D1::ColorF(D2D1::ColorF::Black));
+        d2dRenderTarget->EndDraw();
+    }
     if (formatContext)
     {
         avformat_close_input(&formatContext);
@@ -194,6 +205,8 @@ void VideoPlayer::UnloadVideo()
     currentPts = 0.0;
     totalFrames = 0;
     duration = 0.0;
+    frameWidth = 0;
+    frameHeight = 0;
     cropRect = {0,0,0,0};
     cropStack.clear();
     hasCrop = false;


### PR DESCRIPTION
## Summary
- Release D2D bitmap and clear render target when unloading a video
- Reset frame dimensions after unload to avoid reusing previous sizes

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR, AVCODEC_LIBRARY, AVFORMAT_LIBRARY, AVUTIL_LIBRARY, RNNOISE_LIBRARY, SWRESAMPLE_LIBRARY, SWSCALE_LIBRARY not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5f8c6b74832f82f63578215e077a