### PR TITLE
Set bitrate field to video's average bitrate

### DIFF
--- a/src/file_handling.cpp
+++ b/src/file_handling.cpp
@@ -89,6 +89,43 @@ void LoadVideoFile(HWND hwnd, const std::wstring& filename)
 
         UpdateControls();
         UpdateTimeline();
+
+        // Set bitrate field to the video's average bitrate
+        if (g_hEditBitrate && g_videoPlayer && g_videoPlayer->formatContext)
+        {
+            int videoKbps = 0;
+            int64_t containerBitRate = g_videoPlayer->formatContext->bit_rate;
+            if (containerBitRate <= 0 && g_videoPlayer->duration > 0)
+            {
+                try
+                {
+                    auto fileSize = std::filesystem::file_size(filename);
+                    containerBitRate = static_cast<int64_t>((fileSize * 8) / g_videoPlayer->duration);
+                }
+                catch (...)
+                {
+                    containerBitRate = 0;
+                }
+            }
+
+            if (containerBitRate > 0)
+            {
+                int64_t audioBitrate = 0;
+                for (const auto& track : g_videoPlayer->audioTracks)
+                {
+                    AVStream* stream = g_videoPlayer->formatContext->streams[track->streamIndex];
+                    int br = stream->codecpar->bit_rate > 0 ? stream->codecpar->bit_rate : 128000;
+                    audioBitrate += br;
+                }
+                int64_t videoBitrate = containerBitRate - audioBitrate;
+                if (videoBitrate <= 0)
+                    videoBitrate = containerBitRate;
+                videoKbps = static_cast<int>(videoBitrate / 1000);
+            }
+
+            SetWindowTextW(g_hEditBitrate, std::to_wstring(videoKbps).c_str());
+        }
+
         if (g_autoPlay)
         {
             g_videoPlayer->Play();

--- a/src/ui_controls.cpp
+++ b/src/ui_controls.cpp
@@ -309,7 +309,7 @@ void CreateControls(HWND hwnd)
     ApplyDarkTheme(g_hLabelBitrate);
 
     g_hEditBitrate = CreateWindow(
-        L"EDIT", L"8000",
+        L"EDIT", L"0",
         WS_VISIBLE | WS_CHILD | WS_BORDER | ES_NUMBER,
         340, 585, 200, 20,
         hwnd, (HMENU)ID_EDIT_BITRATE,


### PR DESCRIPTION
## Summary
- Initialize bitrate input to 0 instead of hardcoded 8000
- Fill bitrate field with the video's average bitrate after loading a file

## Testing
- `cmake -S . -B build` *(fails: FFMPEG_INCLUDE_DIR not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af85687eb8832fb9364c87afd1ff78